### PR TITLE
Fix defaults in pcm16_to_wav_bytes docstring

### DIFF
--- a/maxim/logger/utils.py
+++ b/maxim/logger/utils.py
@@ -48,8 +48,8 @@ def pcm16_to_wav_bytes(
 
     Args:
         pcm_bytes (bytes): Raw PCM-16 audio data
-        num_channels (int): Number of audio channels (default: 2)
-        sample_rate (int): Sample rate in Hz (default: 44100)
+        num_channels (int): Number of audio channels (default: 1)
+        sample_rate (int): Sample rate in Hz (default: 24000)
 
     Returns:
         bytes: WAV format audio data


### PR DESCRIPTION
## Summary
- correct documented defaults for `pcm16_to_wav_bytes`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'filetype')*

------
https://chatgpt.com/codex/tasks/task_e_683ff516099083208f9ff8d3ee5cad62