### PR TITLE
Add Mistral logger

### DIFF
--- a/maxim/logger/mistral/__init__.py
+++ b/maxim/logger/mistral/__init__.py
@@ -1,0 +1,11 @@
+import importlib.util
+
+from .client import MaximMistralClient
+from .utils import MistralUtils
+
+if importlib.util.find_spec("mistralai") is None:
+    raise ImportError(
+        "The mistralai package is required. Please install it using pip: `pip install mistralai`"
+    )
+
+__all__ = ["MaximMistralClient", "MistralUtils"]

--- a/maxim/logger/mistral/client.py
+++ b/maxim/logger/mistral/client.py
@@ -1,0 +1,215 @@
+from typing import Any, List, Optional
+from uuid import uuid4
+
+from mistralai.sdk import Mistral
+from mistralai.chat import Chat
+from mistralai.models import CompletionEvent
+
+from ...scribe import scribe
+from ..logger import Generation, GenerationConfig, Logger, Trace, TraceConfig
+from .utils import MistralUtils
+
+
+class MaximMistralChat:
+    def __init__(self, chat: Chat, logger: Logger):
+        self._chat = chat
+        self._logger = logger
+
+    def complete(self, *args, **kwargs):
+        trace_id = kwargs.pop("trace_id", None)
+        generation_name = kwargs.pop("generation_name", None)
+        is_local_trace = trace_id is None
+        final_trace_id = trace_id or str(uuid4())
+        model = kwargs.get("model")
+        messages = kwargs.get("messages")
+        trace: Optional[Trace] = None
+        generation: Optional[Generation] = None
+        try:
+            trace = self._logger.trace(TraceConfig(id=final_trace_id))
+            gen_config = GenerationConfig(
+                id=str(uuid4()),
+                model=model,
+                provider="mistral",
+                name=generation_name,
+                model_parameters=MistralUtils.get_model_params(**kwargs),
+                messages=MistralUtils.parse_message_param(messages),
+            )
+            generation = trace.generation(gen_config)
+        except Exception as e:
+            scribe().warning(
+                f"[MaximSDK][MaximMistralChat] Error in generating content: {e}"
+            )
+
+        response = self._chat.complete(*args, **kwargs)
+
+        try:
+            if generation is not None:
+                generation.result(MistralUtils.parse_completion(response))
+            if is_local_trace and trace is not None:
+                if response.choices:
+                    text = MistralUtils._message_content(response.choices[0].message)
+                    trace.set_output(text)
+                trace.end()
+        except Exception as e:
+            scribe().warning(
+                f"[MaximSDK][MaximMistralChat] Error in logging generation: {e}"
+            )
+
+        return response
+
+    def stream(self, *args, **kwargs):
+        trace_id = kwargs.pop("trace_id", None)
+        generation_name = kwargs.pop("generation_name", None)
+        is_local_trace = trace_id is None
+        final_trace_id = trace_id or str(uuid4())
+        model = kwargs.get("model")
+        messages = kwargs.get("messages")
+        trace: Optional[Trace] = None
+        generation: Optional[Generation] = None
+        try:
+            trace = self._logger.trace(TraceConfig(id=final_trace_id))
+            gen_config = GenerationConfig(
+                id=str(uuid4()),
+                model=model,
+                provider="mistral",
+                name=generation_name,
+                model_parameters=MistralUtils.get_model_params(**kwargs),
+                messages=MistralUtils.parse_message_param(messages),
+            )
+            generation = trace.generation(gen_config)
+        except Exception as e:
+            scribe().warning(
+                f"[MaximSDK][MaximMistralChat] Error in generating content: {e}"
+            )
+
+        stream = self._chat.stream(*args, **kwargs)
+        chunks: List[dict] = []
+        for event in stream:
+            if isinstance(event, CompletionEvent):
+                chunks.append(MistralUtils.parse_stream_response(event))
+            yield event
+
+        try:
+            if generation is not None:
+                generation.result(MistralUtils.combine_chunks(chunks))
+            if is_local_trace and trace is not None:
+                text = "".join(
+                    chunk.get("delta", {}).get("content", "")
+                    for c in chunks
+                    for chunk in c.get("choices", [])
+                )
+                trace.set_output(text)
+                trace.end()
+        except Exception as e:
+            scribe().warning(
+                f"[MaximSDK][MaximMistralChat] Error in logging generation: {e}"
+            )
+
+    async def complete_async(self, *args, **kwargs):
+        trace_id = kwargs.pop("trace_id", None)
+        generation_name = kwargs.pop("generation_name", None)
+        is_local_trace = trace_id is None
+        final_trace_id = trace_id or str(uuid4())
+        model = kwargs.get("model")
+        messages = kwargs.get("messages")
+        trace: Optional[Trace] = None
+        generation: Optional[Generation] = None
+        try:
+            trace = self._logger.trace(TraceConfig(id=final_trace_id))
+            gen_config = GenerationConfig(
+                id=str(uuid4()),
+                model=model,
+                provider="mistral",
+                name=generation_name,
+                model_parameters=MistralUtils.get_model_params(**kwargs),
+                messages=MistralUtils.parse_message_param(messages),
+            )
+            generation = trace.generation(gen_config)
+        except Exception as e:
+            scribe().warning(
+                f"[MaximSDK][MaximMistralChat] Error in generating content: {e}"
+            )
+
+        response = await self._chat.complete_async(*args, **kwargs)
+
+        try:
+            if generation is not None:
+                generation.result(MistralUtils.parse_completion(response))
+            if is_local_trace and trace is not None:
+                if response.choices:
+                    text = MistralUtils._message_content(response.choices[0].message)
+                    trace.set_output(text)
+                trace.end()
+        except Exception as e:
+            scribe().warning(
+                f"[MaximSDK][MaximMistralChat] Error in logging generation: {e}"
+            )
+
+        return response
+
+    async def stream_async(self, *args, **kwargs):
+        trace_id = kwargs.pop("trace_id", None)
+        generation_name = kwargs.pop("generation_name", None)
+        is_local_trace = trace_id is None
+        final_trace_id = trace_id or str(uuid4())
+        model = kwargs.get("model")
+        messages = kwargs.get("messages")
+        trace: Optional[Trace] = None
+        generation: Optional[Generation] = None
+        try:
+            trace = self._logger.trace(TraceConfig(id=final_trace_id))
+            gen_config = GenerationConfig(
+                id=str(uuid4()),
+                model=model,
+                provider="mistral",
+                name=generation_name,
+                model_parameters=MistralUtils.get_model_params(**kwargs),
+                messages=MistralUtils.parse_message_param(messages),
+            )
+            generation = trace.generation(gen_config)
+        except Exception as e:
+            scribe().warning(
+                f"[MaximSDK][MaximMistralChat] Error in generating content: {e}"
+            )
+
+        stream = await self._chat.stream_async(*args, **kwargs)
+        chunks: List[dict] = []
+        async for event in stream:
+            if isinstance(event, CompletionEvent):
+                chunks.append(MistralUtils.parse_stream_response(event))
+            yield event
+
+        try:
+            if generation is not None:
+                generation.result(MistralUtils.combine_chunks(chunks))
+            if is_local_trace and trace is not None:
+                text = "".join(
+                    chunk.get("delta", {}).get("content", "")
+                    for c in chunks
+                    for chunk in c.get("choices", [])
+                )
+                trace.set_output(text)
+                trace.end()
+        except Exception as e:
+            scribe().warning(
+                f"[MaximSDK][MaximMistralChat] Error in logging generation: {e}"
+            )
+
+
+class MaximMistralClient:
+    def __init__(self, client: Mistral, logger: Logger):
+        self._client = client
+        self._logger = logger
+
+    @property
+    def chat(self) -> MaximMistralChat:
+        return MaximMistralChat(self._client.chat, self._logger)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._client, name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name in {"_client", "_logger"}:
+            super().__setattr__(name, value)
+        else:
+            setattr(self._client, name, value)

--- a/maxim/logger/mistral/utils.py
+++ b/maxim/logger/mistral/utils.py
@@ -1,0 +1,151 @@
+import time
+from typing import Any, Dict, Iterable, List, Optional
+
+from mistralai.models import ChatCompletionResponse, CompletionEvent, CompletionChunk
+
+from ..logger import GenerationRequestMessage
+
+
+class MistralUtils:
+    @staticmethod
+    def parse_message_param(
+        messages: Optional[Iterable[Any]],
+    ) -> List[GenerationRequestMessage]:
+        """Convert Mistral message objects or dictionaries to log-friendly structures."""
+
+        parsed_messages: List[GenerationRequestMessage] = []
+
+        if messages is None:
+            return parsed_messages
+
+        for msg in messages:
+            role = None
+            content = None
+
+            if isinstance(msg, dict):
+                role = msg.get("role", "user")
+                content = msg.get("content", "")
+            else:
+                role = getattr(msg, "role", "user")
+                content = getattr(msg, "content", "")
+
+            parsed_messages.append(
+                GenerationRequestMessage(role=str(role), content=str(content))
+            )
+
+        return parsed_messages
+
+    @staticmethod
+    def get_model_params(**kwargs: Any) -> Dict[str, Any]:
+        model_params: Dict[str, Any] = {}
+        param_keys = [
+            "temperature",
+            "top_p",
+            "max_tokens",
+            "random_seed",
+            "safe_prompt",
+            "n",
+            "stop",
+            "presence_penalty",
+            "frequency_penalty",
+        ]
+        for key in param_keys:
+            if key in kwargs and kwargs[key] is not None:
+                model_params[key] = kwargs[key]
+        for key, value in kwargs.items():
+            if key not in model_params and value is not None:
+                model_params[key] = value
+        return model_params
+
+    @staticmethod
+    def _message_content(message: Any) -> str:
+        """Extract textual content from a Mistral message object."""
+        if not message:
+            return ""
+
+        content = getattr(message, "content", None)
+
+        if isinstance(content, str):
+            return content
+
+        text = ""
+        # Newer SDK versions return a list of ContentChunk instances
+        if isinstance(content, list):
+            for part in content:
+                if hasattr(part, "text") and part.text:
+                    text += str(part.text)
+        else:
+            # Fallback for older SDK versions with `.parts`
+            parts = getattr(content, "parts", None)
+            if parts:
+                for part in parts:
+                    if getattr(part, "text", None):
+                        text += part.text
+
+        return text
+
+    @staticmethod
+    def parse_completion(completion: ChatCompletionResponse) -> Dict[str, Any]:
+        return {
+            "id": completion.id,
+            "created": completion.created,
+            "choices": [
+                {
+                    "index": choice.index,
+                    "message": {
+                        "role": "assistant",
+                        "content": MistralUtils._message_content(choice.message),
+                    },
+                    "finish_reason": getattr(choice, "finish_reason", None),
+                }
+                for choice in completion.choices
+            ],
+            "usage": {
+                "prompt_tokens": completion.usage.prompt_tokens if completion.usage else 0,
+                "completion_tokens": completion.usage.completion_tokens if completion.usage else 0,
+                "total_tokens": completion.usage.total_tokens if completion.usage else 0,
+            },
+        }
+
+    @staticmethod
+    def parse_stream_response(event: CompletionEvent) -> Dict[str, Any]:
+        chunk: CompletionChunk = event.data
+        return {
+            "id": chunk.id,
+            "created": chunk.created or int(time.time()),
+            "choices": [
+                {
+                    "index": c.index,
+                    "delta": {
+                        "role": getattr(c.delta, "role", "assistant"),
+                        "content": MistralUtils._message_content(c.delta),
+                    },
+                    "finish_reason": getattr(c, "finish_reason", None),
+                }
+                for c in chunk.choices
+            ],
+        }
+
+    @staticmethod
+    def combine_chunks(chunks: List[Dict[str, Any]]) -> Dict[str, Any]:
+        if not chunks:
+            return {}
+        last_chunk = chunks[-1]
+        text = "".join(
+            [
+                choice.get("delta", {}).get("content", "")
+                for chunk in chunks
+                for choice in chunk.get("choices", [])
+            ]
+        )
+        return {
+            "id": last_chunk.get("id", ""),
+            "created": last_chunk.get("created", int(time.time())),
+            "choices": [
+                {
+                    "index": last_chunk.get("choices", [{}])[0].get("index", 0),
+                    "message": {"role": "assistant", "content": text},
+                    "finish_reason": last_chunk.get("choices", [{}])[0].get("finish_reason"),
+                }
+            ],
+        }


### PR DESCRIPTION
## Summary
- implement a basic Mistral integration
- provide helper utilities for parsing Mistral responses
- fix message parsing for the Mistral SDK

## Testing
- `python3 -m py_compile maxim/logger/mistral/*.py`
- `python3 -m pytest -k openai -q` *(fails: ModuleNotFoundError: No module named 'filetype')*


------
https://chatgpt.com/codex/tasks/task_e_683ff557acc08320b8a85c27885bb6b6