### PR TITLE
version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,13 @@ You can find detailed documentation and available integrations [here](https://ww
 
 ## Version changelog
 
+### 3.8.1
+- feat: Adds files support for test_runs
+- feat: Adds mistral tracing support
+
 ### 3.8.0
 
 - breaking change: We have renamed a few entities used in test runs.
-- feat: Adds files support for test_runs
-- feat: Adds mistral tracing support
 
 ### 3.7.3
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "maxim-py"
-version = "3.8.0"
+version = "3.8.1"
 description = "A package that allows you to use the Maxim Python Library to interact with the Maxim Platform."
 readme = "README.md"
 requires-python = ">=3.9.20"


### PR DESCRIPTION
### TL;DR

Bump version from 3.8.0 to 3.8.1 and update changelog.

### What changed?

- Updated version number from 3.8.0 to 3.8.1 in `pyproject.toml`
- Moved the "files support for test_runs" and "mistral tracing support" features from version 3.8.0 to 3.8.1 in the changelog

### How to test?

- Verify that the version number in `pyproject.toml` is correctly set to 3.8.1
- Confirm that the changelog correctly lists the features under version 3.8.1

### Why make this change?

The features for files support and mistral tracing were incorrectly listed under version 3.8.0 but should be part of the 3.8.1 release. This PR corrects the versioning to ensure proper documentation of when these features were introduced.