### PR TITLE
[Bug Fix] fixes retrieved context to evaluate not being sent to the server for yields output in case there was no CONTEXT_TO_EVALUATE column in the dataset

### DIFF
--- a/maxim/test_runs/test_run_builder.py
+++ b/maxim/test_runs/test_run_builder.py
@@ -252,7 +252,7 @@ class TestRunBuilder(Generic[T]):
                 logger.info(
                     "Overriding context_to_evaluate from output over dataset entry"
                 )
-                context_to_evaluate = yielded_output.retrieved_context_to_evaluate
+            context_to_evaluate = yielded_output.retrieved_context_to_evaluate
 
         local_evaluators: List[BaseEvaluator] = []
         for evaluator in self._config.evaluators:


### PR DESCRIPTION
Fixed indentation bug in TestRunBuilder where context_to_evaluate assignment was incorrectly indented inside the if block. This change ensures that context_to_evaluate is always assigned to yielded_output.retrieved_context_to_evaluate when the condition is met.
