### PR TITLE
adds session_id, room_name as tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ You can find detailed documentation and available integrations [here](https://ww
 
 ## Version changelog
 
+### 3.8.5
+
+- chore: Adds session_id and room_id 
+
 ### 3.8.4
 
 - fix: Fixes gemini + langchain integration to capture None finish_reason and usage_metadata

--- a/maxim/logger/components/utils.py
+++ b/maxim/logger/components/utils.py
@@ -33,9 +33,8 @@ def parse_attachments_from_messages(
     attachments = []
     for message in messages:
         content = message.get("content", [])
-        if content is None:
+        if content is None or isinstance(content, str):
             continue
-
         # Iterate in reverse order to safely remove items while iterating
         for i in range(len(content) - 1, -1, -1):
             item = content[i]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "maxim-py"
-version = "3.8.4"
+version = "3.8.5"
 description = "A package that allows you to use the Maxim Python Library to interact with the Maxim Platform."
 readme = "README.md"
 requires-python = ">=3.9.20"


### PR DESCRIPTION
### TL;DR

Added room name tracking to LiveKit agent sessions and enhanced session tagging.

### What changed?

- Added support for tracking `room_name` alongside `room_id` in LiveKit agent sessions
- Added logic to extract room name from different room object types (string, Room object, dictionary)
- Enhanced session tagging by adding additional tags:
  - `room_id`
  - `room_name`
  - `session_id`
  - `agent_id`
- Added `session_id` to the tags dictionary in the session started event

### How to test?

1. Create a LiveKit agent session with different room input types:
   - String room ID
   - Room object
   - Dictionary with a name field
2. Verify that the room name is correctly captured in session tags
3. Check that all expected tags (`room_id`, `room_name`, `session_id`, `agent_id`) are present in the session

### Why make this change?

This change improves session tracking and debugging capabilities by capturing more meaningful identifiers. The room name provides a human-readable identifier alongside the technical room ID, making it easier to identify and track specific sessions in logs and monitoring tools.