### PR TITLE
fix: fixes enable_prompt_management method call

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ You can find detailed documentation and available integrations [here](https://ww
 
 ## Version changelog
 
+### 3.9.1
+
+- fix: Fixes `enable_prompt_management` method bug. 
+
 ### 3.9.0
 
 - fix: Some minor fixes in Maxim log repo checks, Anthropic client and Gemini client

--- a/maxim/maxim.py
+++ b/maxim/maxim.py
@@ -151,15 +151,17 @@ class Maxim:
         self.__is_debug = final_config.get("debug", False)
         self.__loggers: Dict[str, Logger] = {}
         self.prompt_management = final_config.get("prompt_management", False)
+        self.__cache = final_config.get("cache", MaximInMemoryCache())
         if self.prompt_management:
-            self.__cache = final_config.get("cache", MaximInMemoryCache())
             self.__sync_thread = threading.Thread(target=self.__sync_timer)
             self.__sync_thread.daemon = True
             self.__sync_thread.start()
+        else:
+            self.__sync_thread = None
 
     def enable_prompt_management(self) -> "Maxim":
         self.prompt_management = True
-        if not self.__sync_thread.is_alive():
+        if not self.__sync_thread or not self.__sync_thread.is_alive():
             self.__sync_thread = threading.Thread(target=self.__sync_timer)
             self.__sync_thread.daemon = True
             self.__sync_thread.start()

--- a/maxim/scribe.py
+++ b/maxim/scribe.py
@@ -16,9 +16,8 @@ class Scribe:
 
     def __init__(self, name):
         self.name = name
-        self.disable_internal_logs = False
+        self.disable_internal_logs = True
         self.logger = logging.getLogger(name)        
-        
 
     def _should_log(self, msg):
         return not (
@@ -57,7 +56,7 @@ class Scribe:
 
     def get_level(self):
         return self.logger.level
-    
+
     def set_level(self, level):
         self.logger.setLevel(level)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "maxim-py"
-version = "3.9.0"
+version = "3.9.1"
 description = "A package that allows you to use the Maxim Python Library to interact with the Maxim Platform."
 readme = "README.md"
 requires-python = ">=3.9.20"


### PR DESCRIPTION
### TL;DR

Fixed a bug in the `enable_prompt_management` method and updated internal logging defaults.

### What changed?

- Fixed a bug in the `enable_prompt_management` method where it would fail if `__sync_thread` was not initialized
- Initialized `__cache` regardless of whether prompt management is enabled
- Set `disable_internal_logs` to `True` by default in the `Scribe` class
- Bumped version from 3.9.0 to 3.9.1 in pyproject.toml and updated the changelog

### How to test?

1. Call `enable_prompt_management()` on a Maxim instance that was initialized with prompt management disabled
2. Verify that the method executes without errors and properly enables prompt management
3. Check that internal logs are disabled by default

### Why make this change?

The `enable_prompt_management` method would fail when called on a Maxim instance that was initialized with prompt management disabled, as it tried to check if `__sync_thread` was alive before it was initialized. This fix ensures the method works correctly in all scenarios and improves the default logging behavior.