### PR TITLE
updates makefile to automatically create releases on github

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,24 @@ publish:
 	. .venv/bin/activate && \
 	python3 -m build && \
 	twine upload dist/*
+	@echo "Package published successfully, creating GitHub release..."
+	@VERSION=$$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/'); \
+	echo "Creating tag and release for version: $$VERSION"; \
+	git tag -a "v$$VERSION" -m "Release v$$VERSION" || echo "Tag already exists"; \
+	git push origin "v$$VERSION" || echo "Tag already pushed"; \
+	echo "import re, sys" > /tmp/extract_notes.py; \
+	echo "with open('README.md', 'r') as f: content = f.read()" >> /tmp/extract_notes.py; \
+	echo "version = sys.argv[1]" >> /tmp/extract_notes.py; \
+	echo "pattern = f'### {version}\\\\n([\\\\s\\\\S]*?)(?=\\\\n### |\\\\n\\\\n##|$$)'" >> /tmp/extract_notes.py; \
+	echo "match = re.search(pattern, content)" >> /tmp/extract_notes.py; \
+	echo "notes = match.group(1).strip() if match else f'Release notes for version {version}'" >> /tmp/extract_notes.py; \
+	echo "print(notes)" >> /tmp/extract_notes.py; \
+	python3 /tmp/extract_notes.py $$VERSION > /tmp/release_notes.txt; \
+	gh release create "v$$VERSION" \
+		--title "Release v$$VERSION" \
+		--notes-file /tmp/release_notes.txt \
+		--verify-tag || echo "Release creation failed or already exists"; \
+	rm -f /tmp/release_notes.txt /tmp/extract_notes.py
 
 # Documentation commands
 docs: docs-clean


### PR DESCRIPTION
### TL;DR

Automate GitHub release creation when publishing a package.

### What changed?

Enhanced the `publish` target in the Makefile to automatically:
- Create a git tag for the current version from pyproject.toml
- Push the tag to the remote repository
- Extract release notes from the README.md file for the current version
- Create a GitHub release using the extracted notes via the GitHub CLI

### How to test?

1. Update the version in pyproject.toml
2. Add release notes for the new version in README.md
3. Run `make publish` to publish the package
4. Verify that a new GitHub release is created with the correct version and notes

### Why make this change?

Streamlines the release process by automating the GitHub release creation after package publishing, ensuring consistency between PyPI releases and GitHub releases while also capturing release notes from the README documentation.