### PR TITLE
langgraph tool call fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ You can find detailed documentation and available integrations [here](https://ww
 
 ## Version changelog
 
+### 3.9.7
+
+- improvement: Adds support for uploading large payloads as part of logs.
+
 ### 3.9.6
 
 - improvement: Increased connection pool max size to 20 for more connections at high throughput. 

--- a/maxim/apis/maxim_apis.py
+++ b/maxim/apis/maxim_apis.py
@@ -65,8 +65,8 @@ class ConnectionPool:
         timeout = httpx.Timeout(
             connect=15.0,
             read=30.0,
-            write=30.0,
-            pool=60.0,
+            write=120.0,
+            pool=120.0,
         )
 
         self.client = httpx.Client(

--- a/maxim/logger/langchain/utils.py
+++ b/maxim/logger/langchain/utils.py
@@ -158,12 +158,16 @@ def parse_langchain_message(message: BaseMessage):
                 "role": "assistant",
                 "content": message.content,
             },
-            "finish_reason": message.response_metadata["finish_reason"]
-            if message.response_metadata["finish_reason"]
-            else None,
-            "logprobs": message.response_metadata["logprobs"]
-            if message.response_metadata["logprobs"]
-            else None,
+            "finish_reason": (
+                message.response_metadata["finish_reason"]
+                if message.response_metadata["finish_reason"]
+                else None
+            ),
+            "logprobs": (
+                message.response_metadata["logprobs"]
+                if message.response_metadata["logprobs"]
+                else None
+            ),
         }
 
 
@@ -219,9 +223,11 @@ def parse_langchain_chat_generation_chunk(generation: ChatGeneration):
             "index": 0,
             "message": {"role": "assistant", "content": content, "tool_calls": []},
             "finish_reason": finish_reason,
-            "logprobs": generation.generation_info.get("logprobs")
-            if generation.generation_info
-            else None,
+            "logprobs": (
+                generation.generation_info.get("logprobs")
+                if generation.generation_info
+                else None
+            ),
         }
     )
     return choices
@@ -296,9 +302,11 @@ def parse_langchain_chat_generation(generation: ChatGeneration):
                     "tool_calls": parse_langchain_tool_call(tool_calls),
                 },
                 "finish_reason": finish_reason,
-                "logprobs": generation.generation_info.get("logprobs")
-                if generation.generation_info
-                else None,
+                "logprobs": (
+                    generation.generation_info.get("logprobs")
+                    if generation.generation_info
+                    else None
+                ),
             }
         )
     return choices
@@ -309,12 +317,16 @@ def parse_langchain_generation_chunk(generation: GenerationChunk):
         {
             "index": 0,
             "text": generation.text,
-            "logprobs": generation.generation_info.get("logprobs")
-            if generation.generation_info
-            else None,
-            "finish_reason": generation.generation_info.get("finish_reason")
-            if generation.generation_info
-            else "stop",
+            "logprobs": (
+                generation.generation_info.get("logprobs")
+                if generation.generation_info
+                else None
+            ),
+            "finish_reason": (
+                generation.generation_info.get("finish_reason")
+                if generation.generation_info
+                else "stop"
+            ),
         }
     ]
 
@@ -328,12 +340,16 @@ def parse_langchain_text_generation(generation: Generation):
                 {
                     "index": i,
                     "text": message["content"],
-                    "logprobs": generation.generation_info.get("logprobs")
-                    if generation.generation_info
-                    else None,
-                    "finish_reason": generation.generation_info.get("finish_reason")
-                    if generation.generation_info
-                    else None,
+                    "logprobs": (
+                        generation.generation_info.get("logprobs")
+                        if generation.generation_info
+                        else None
+                    ),
+                    "finish_reason": (
+                        generation.generation_info.get("finish_reason")
+                        if generation.generation_info
+                        else None
+                    ),
                 }
             )
     return choices
@@ -588,7 +604,11 @@ def parse_langchain_messages(
                         )
                     elif message_type.endswith("ToolMessage"):
                         messages.append(
-                            {"role": "tool", "content": message.content or ""}
+                            {
+                                "role": "tool",
+                                "content": message.content or "",
+                                "tool_call_id": message.tool_call_id,
+                            }
                         )
                     else:
                         logger.error(f"Invalid message type: {type(message)}")

--- a/maxim/logger/livekit/agent_activity.py
+++ b/maxim/logger/livekit/agent_activity.py
@@ -64,6 +64,14 @@ def handle_input_speech_started(self: AgentActivity):
         session_info.current_turn.is_interrupted = True
         get_session_store().set_session(session_info)
         return
+    # here we can check if the current turn is interrupted
+    if (
+        session_info.current_turn is not None
+        and session_info.current_turn.turn_input_audio_buffer.tell() == 0
+        and session_info.current_turn.turn_output_audio_buffer.tell() == 0
+    ):
+        # we will reuse the same turn
+        return
     start_new_turn(session_info)
 
 

--- a/maxim/logger/logger.py
+++ b/maxim/logger/logger.py
@@ -10,6 +10,7 @@ Attributes:
     flush_interval (int): The interval (in seconds) at which to flush logs when auto_flush is True. Defaults to 10 seconds.
 """
 
+import json
 import threading
 from typing import Any, Dict, Optional, TypedDict, Union
 
@@ -836,7 +837,7 @@ class Logger:
         """
         ToolCall.update_(self.writer, tool_call_id, data)
 
-    def tool_call_result(self, tool_call_id: str, result: Any):
+    def tool_call_result(self, tool_call_id: str, result: str):
         """
         Sets the result for the tool call.
 
@@ -844,6 +845,8 @@ class Logger:
             tool_call_id (str): The ID of the tool call.
             result (Any): The result for the tool call.
         """
+        if not isinstance(result, str):
+            result = json.dumps(result)
         ToolCall.result_(self.writer, tool_call_id, result)
 
     def tool_call_error(

--- a/maxim/scribe.py
+++ b/maxim/scribe.py
@@ -127,8 +127,12 @@ class Scribe:
 def scribe():
     global _scribe_instance
     if _scribe_instance is None:
-        _scribe_instance = Scribe("maxim")        
-        if _scribe_instance.get_level() == logging.NOTSET:
+        _scribe_instance = Scribe("maxim")
+        # Take global logging level and set it for _scribe_instance if set
+        root_level = logging.getLogger().getEffectiveLevel()
+        if root_level != logging.NOTSET:
+            _scribe_instance.set_level(root_level)
+        elif _scribe_instance.get_level() == logging.NOTSET:
             print("\033[32m[MaximSDK] Using info logging level.\033[0m")
             print(
                 "\033[32m[MaximSDK] For debug logs, set global logging level to debug logging.basicConfig(level=logging.DEBUG).\033[0m"

--- a/maxim/tests/test_logger_large_payloads.py
+++ b/maxim/tests/test_logger_large_payloads.py
@@ -1,0 +1,77 @@
+import os
+import time
+from uuid import uuid4
+from dotenv import load_dotenv
+
+from maxim.maxim import Maxim
+
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+# Load environment variables from .env file
+load_dotenv(override=True)
+
+maxim = Maxim(
+    {
+        "api_key": os.getenv("MAXIM_API_KEY"),
+        "base_url": os.getenv("MAXIM_BASE_URL"),
+        "debug": True,
+    }
+)
+
+
+# Initializing logger
+logger = maxim.logger({"id": os.getenv("MAXIM_LOG_REPO_ID")})
+
+print(os.getenv("MAXIM_LOG_REPO_ID"))
+
+for i in range(10):
+
+    trace = logger.trace({"id": str(uuid4()), "name": "pre-defined-trace"})
+
+    generation = trace.generation(
+        {
+            "id": str(uuid4()),
+            "name": "customer-support--gather-information",
+            "provider": "openai",
+            "model": "gpt-4o",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "you are an helpful assistant who helps gather customer information",
+                },
+                {"role": "user", "content": "My internet is not working"},
+            ],
+            "model_parameters": {"temperature": 0.7},
+        }
+    )
+
+    generation.result(
+        {
+            "id": "chatcmpl-123",
+            "object": "chat.completion",
+            "created": int(time.time()),
+            "model": "gpt-4o",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "Lol ¯\_(ツ)_/¯ "
+                        * (2 * 1024 * 1024 // len("Lol ¯\_(ツ)_/¯ ")),
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 50,
+                "total_tokens": 150,
+            },
+        }
+    )
+
+    trace.end()
+logger.flush()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "maxim-py"
-version = "3.9.6"
+version = "3.9.7"
 description = "A package that allows you to use the Maxim Python Library to interact with the Maxim Platform."
 readme = "README.md"
 requires-python = ">=3.9.20"
 dependencies = [
     "typing-extensions",
     "filetype",
-    "httpx>=0.28.1",
+    "httpx>=0.28.1"    
 ]
 authors = [
   { name = "Maxim Engineering", email = "eng@getmaxim.ai" }

--- a/uv.lock
+++ b/uv.lock
@@ -262,13 +262,10 @@ wheels = [
 name = "boto3"
 version = "1.7.84"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
 dependencies = [
-    { name = "botocore", version = "1.10.84", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "jmespath", marker = "python_full_version < '3.10'" },
-    { name = "s3transfer", version = "0.1.13", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2f/2b/7010a5189859eec725c36081b1d1c8e721000ebdf81a1682ec6b64e1c373/boto3-1.7.84.tar.gz", hash = "sha256:64496f2c814e454e26c024df86bd08fb4643770d0e2b7a8fd70055fc6683eb9d", size = 93151 }
 wheels = [
@@ -276,60 +273,17 @@ wheels = [
 ]
 
 [[package]]
-name = "boto3"
-version = "1.38.36"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.13'",
-    "python_full_version >= '3.12.4' and python_full_version < '3.13'",
-    "python_full_version >= '3.11' and python_full_version < '3.12.4'",
-    "python_full_version == '3.10.*'",
-]
-dependencies = [
-    { name = "botocore", version = "1.38.36", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "jmespath", marker = "python_full_version >= '3.10'" },
-    { name = "s3transfer", version = "0.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/22/df130d30dcc73b726c3d254ed855806853b86b987052517337587085b6db/boto3-1.38.36.tar.gz", hash = "sha256:efe0aaa060f8fedd76e5c942055f051aee0432fc722d79d8830a9fd9db83593e", size = 111823 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/ce/f609adc7dfd53792a9b704aa1241f8e5f34c21a5364f64b114d7874f8327/boto3-1.38.36-py3-none-any.whl", hash = "sha256:34c27d7317cadb62c0e9856e5d5aa0271ef47202d340584831048bc7ac904136", size = 139938 },
-]
-
-[[package]]
 name = "botocore"
 version = "1.10.84"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
 dependencies = [
-    { name = "docutils", marker = "python_full_version < '3.10'" },
-    { name = "jmespath", marker = "python_full_version < '3.10'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.10'" },
+    { name = "docutils" },
+    { name = "jmespath" },
+    { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/01/43759329a6f7036aa739e86d446b908fa207222e224e537cd3d66fdb4c29/botocore-1.10.84.tar.gz", hash = "sha256:d3e4b5a2c903ea30d19d41ea2f65d0e51dce54f4f4c4dfd6ecd7b04f240844a8", size = 4612644 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/01/b7/cb08cd1af2bb0d0dfb393101a93b6ab6fb80f109ab7b37f2f34386c11351/botocore-1.10.84-py2.py3-none-any.whl", hash = "sha256:380852e1adb9ba4ba9ff096af61f88a6888197b86e580e1bd786f04ebe6f9c0c", size = 4478913 },
-]
-
-[[package]]
-name = "botocore"
-version = "1.38.36"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.13'",
-    "python_full_version >= '3.12.4' and python_full_version < '3.13'",
-    "python_full_version >= '3.11' and python_full_version < '3.12.4'",
-    "python_full_version == '3.10.*'",
-]
-dependencies = [
-    { name = "jmespath", marker = "python_full_version >= '3.10'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.10'" },
-    { name = "urllib3", marker = "python_full_version >= '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/2e/15/d218917f2d568f6fa92ad3831b31ecc4ee514d775a142385aa87c672bc08/botocore-1.38.36.tar.gz", hash = "sha256:4a1ced1a4218bdff0ed5b46abb54570d473154ddefafa5d121a8d96e4b76ebc1", size = 13966245 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/2d/3ccc58837b3ed8322a15b9fd94114a326e6ab29d36a37508aadf9cf7808e/botocore-1.38.36-py3-none-any.whl", hash = "sha256:b6a50b853f6d23af9edfed89a59800c6bc1687a947cdd3492879f7d64e002d30", size = 13623866 },
 ]
 
 [[package]]
@@ -593,7 +547,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749 }
 wheels = [
@@ -1696,10 +1650,8 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "anthropic" },
-    { name = "boto3", version = "1.7.84", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "boto3", version = "1.38.36", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "botocore", version = "1.10.84", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "botocore", version = "1.38.36", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "boto3" },
+    { name = "botocore" },
     { name = "build" },
     { name = "filetype" },
     { name = "flask" },
@@ -1730,7 +1682,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "filetype" },
-    { name = "httpx" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "typing-extensions" },
 ]
 
@@ -3143,33 +3095,12 @@ wheels = [
 name = "s3transfer"
 version = "0.1.13"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
 dependencies = [
-    { name = "botocore", version = "1.10.84", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "botocore" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9a/66/c6a5ae4dbbaf253bd662921b805e4972451a6d214d0dc9fb3300cb642320/s3transfer-0.1.13.tar.gz", hash = "sha256:90dc18e028989c609146e241ea153250be451e05ecc0c2832565231dacdf59c1", size = 103335 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/14/2a0004d487464d120c9fb85313a75cd3d71a7506955be458eebfe19a6b1d/s3transfer-0.1.13-py2.py3-none-any.whl", hash = "sha256:c7a9ec356982d5e9ab2d4b46391a7d6a950e2b04c472419f5fdec70cc0ada72f", size = 59642 },
-]
-
-[[package]]
-name = "s3transfer"
-version = "0.13.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.13'",
-    "python_full_version >= '3.12.4' and python_full_version < '3.13'",
-    "python_full_version >= '3.11' and python_full_version < '3.12.4'",
-    "python_full_version == '3.10.*'",
-]
-dependencies = [
-    { name = "botocore", version = "1.38.36", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/5d/9dcc100abc6711e8247af5aa561fc07c4a046f72f659c3adea9a449e191a/s3transfer-0.13.0.tar.gz", hash = "sha256:f5e6db74eb7776a37208001113ea7aa97695368242b364d73e91c981ac522177", size = 150232 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/17/22bf8155aa0ea2305eefa3a6402e040df7ebe512d1310165eda1e233c3f8/s3transfer-0.13.0-py3-none-any.whl", hash = "sha256:0148ef34d6dd964d0d8cf4311b2b21c474693e57c2e069ec708ce043d2b527be", size = 85152 },
 ]
 
 [[package]]


### PR DESCRIPTION
### TL;DR

Enhanced LangChain tracer to better handle tool messages and improved evaluator integration for LLM generations.

### What changed?

- Added support for `ToolMessage` handling in `on_tool_end` method
- Fixed parsing of LangChain messages to include `tool_call_id` for tool messages
- Improved extraction of user input messages for evaluation purposes
- Enhanced error handling in JSON serialization for tool call results
- Fixed conditional logic in evaluator attachment for LLM generations
- Improved session management in LiveKit agent activity to prevent unnecessary turn creation
- Standardized parentheses formatting in conditional expressions
- Renamed `get_upload_url` to `get_attachment_upload_url` for clarity
- Added large log handling capability to process logs exceeding size limits

### How to test?

1. Test LangChain integration with a workflow that uses tool calls
2. Verify that tool messages are properly captured and displayed in the UI
3. Test evaluator integration with LangGraph nodes
4. Verify that interrupted speech sessions are handled correctly
5. Test uploading large logs to ensure they're properly processed

### Why make this change?

These changes improve the robustness of the LangChain tracer, particularly when working with tool calls and evaluations. The enhanced handling of tool messages ensures that all relevant data is properly captured and displayed. The improvements to evaluator integration make it more reliable when working with LangGraph nodes. The session management improvements prevent unnecessary turn creation in certain scenarios, leading to a more accurate representation of conversations. The large log handling capability ensures that logs exceeding size limits are properly processed and stored.