### PR TITLE
removes singnal handlers from the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ See [cookbook/agno_agent.py](cookbook/agno_agent.py) for an example of tracing a
 
 ## Version changelog
 
+### 3.9.10
+
+- fix: removes signal handlers from the package.
+
 ### 3.9.9
 
 - feat: Adds one line integration for Together AI SDK

--- a/maxim/maxim.py
+++ b/maxim/maxim.py
@@ -146,9 +146,6 @@ class Maxim:
             Maxim._instance = self
         self.has_cleaned_up = False
         atexit.register(self.cleanup)
-        if threading.current_thread() is threading.main_thread():
-            signal.signal(signal.SIGINT, self._signal_handler)
-            signal.signal(signal.SIGTERM, self._signal_handler)
         self.ascii_logo = (
             f"\033[32m[MaximSDK] Initializing Maxim AI(v{current_version})\033[0m"
         )
@@ -1001,22 +998,6 @@ class Maxim:
             Optional[PromptResponse]: The completion response if successful, None otherwise
         """
         return self.maxim_api.run_prompt(model, messages, tools, **kwargs)
-
-    def _signal_handler(self, signum, frame):
-        """
-        Handles system signals (SIGINT, SIGTERM) for graceful shutdown.
-
-        This method ensures proper cleanup when the application receives termination signals.
-
-        Args:
-            signum: The signal number that was received.
-            frame: The current stack frame (unused).
-        """
-        if self.has_cleaned_up:
-            return
-        self.has_cleaned_up = True
-        self.cleanup()
-        sys.exit(0)
 
     def cleanup(self):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "maxim-py"
-version = "3.9.9"
+version = "3.9.10"
 description = "A package that allows you to use the Maxim Python Library to interact with the Maxim Platform."
 readme = "README.md"
 requires-python = ">=3.9.20"


### PR DESCRIPTION
### TL;DR

Removed signal handlers from the Maxim SDK package and bumped version to 3.9.10.

### What changed?

- Removed the signal handler code from the `maxim.py` file that was previously registering handlers for SIGINT and SIGTERM signals
- Removed the `_signal_handler` method that was handling these signals
- Updated version from 3.9.9 to 3.9.10 in `pyproject.toml`
- Added a changelog entry in `README.md` documenting this fix

### How to test?

1. Install the updated package
2. Verify that the application using Maxim SDK can handle its own signal interrupts without interference
3. Confirm that the SDK still cleans up properly on exit via the registered atexit handler

### Why make this change?

Signal handlers should typically be managed by the application using the SDK rather than by the SDK itself. The previous implementation could interfere with the application's own signal handling, potentially causing issues with graceful shutdown processes. This change allows applications to implement their own signal handling while still ensuring the SDK cleans up properly through the atexit mechanism.