### PR TITLE
handles prompt custom type for langchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ See [cookbook/agno_agent.py](cookbook/agno_agent.py) for an example of tracing a
 
 ## Version changelog
 
+### 3.9.11
+
+- feat: Adds support for PROMPT_TYPE_CUSTOM for langchain
+
 ### 3.9.10
 
 - fix: removes signal handlers from the package.

--- a/maxim/logger/langchain/utils.py
+++ b/maxim/logger/langchain/utils.py
@@ -232,7 +232,8 @@ def parse_langchain_chat_generation_chunk(generation: ChatGeneration):
     )
     return choices
 
-def get_action_from_kwargs(kwargs:Dict[str, Any])-> Optional[Dict]:
+
+def get_action_from_kwargs(kwargs: Dict[str, Any]) -> Optional[Dict]:
     """
     Extract action from tool outputs in kwargs.
 
@@ -251,6 +252,7 @@ def get_action_from_kwargs(kwargs:Dict[str, Any])-> Optional[Dict]:
         return None
     except (KeyError, IndexError, TypeError) as e:
         return None
+
 
 def parse_langchain_chat_generation(generation: ChatGeneration):
     choices = []
@@ -275,7 +277,7 @@ def parse_langchain_chat_generation(generation: ChatGeneration):
         )
         content = ""
         actions = get_action_from_kwargs(ai_message.additional_kwargs)
-        actions_dict = {'Action': actions}
+        actions_dict = {"Action": actions}
         if actions:
             content += json.dumps(actions_dict)
         if isinstance(ai_message.content, str):
@@ -608,6 +610,13 @@ def parse_langchain_messages(
                                 "role": "tool",
                                 "content": message.content or "",
                                 "tool_call_id": message.tool_call_id,
+                            }
+                        )
+                    elif message_type.endswith("ChatMessage"):
+                        messages.append(
+                            {
+                                "role": message.role,
+                                "content": message.content or "",
                             }
                         )
                     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "maxim-py"
-version = "3.9.10"
+version = "3.9.11"
 description = "A package that allows you to use the Maxim Python Library to interact with the Maxim Platform."
 readme = "README.md"
 requires-python = ">=3.9.20"


### PR DESCRIPTION
### TL;DR

Added support for PROMPT_TYPE_CUSTOM in langchain integration.

### What changed?

- Added support for handling custom chat messages in the langchain integration by adding a condition to parse messages with type ending in "ChatMessage"
- Updated the version from 3.9.10 to 3.9.11 in both README.md and pyproject.toml
- Fixed code formatting in the `get_action_from_kwargs` function
- Standardized quotes in the `actions_dict` variable from single to double quotes

### How to test?

1. Use a custom chat message type with the langchain integration
2. Verify that messages with role and content are properly parsed and logged
3. Ensure backward compatibility with existing message types

### Why make this change?

This change enhances the flexibility of the langchain integration by supporting custom chat message types, allowing users to implement custom prompt formats while still maintaining compatibility with the Maxim logging system.