### PR TITLE
[Maxim PY] Fixes tool parsing errors

### DIFF
--- a/maxim/logger/components/generation.py
+++ b/maxim/logger/components/generation.py
@@ -694,11 +694,8 @@ class Generation(BaseContainer):
             self._commit("result", {"result": result})
             self.end()
         except ValueError as e:
-            import traceback
-
             scribe().error(
                 f"[MaximSDK] Invalid result. You can pass OpenAI/Azure ChatCompletion or Langchain LLMResult, AIMessage, ToolMessage, Gemini result or LiteLLM ModelResponse: {str(e)}",
-                traceback.format_exc(),
             )
 
     def error(self, error: Union[GenerationError, GenerationErrorTypedDict]):

--- a/maxim/logger/components/utils.py
+++ b/maxim/logger/components/utils.py
@@ -36,8 +36,14 @@ def parse_attachments_from_messages(
         content = message.get("content", [])
         role = message.get("role", "")
         if role == "tool" and isinstance(content, str):
-            content = json.loads(content)
-            content = [content]
+            try:
+                content = json.loads(content)
+                content = [content]
+            except Exception as e:
+                scribe().debug(
+                    f"[MaximSDK] Error while parsing attachment (Failed to parse tool message): {str(e)}"
+                )
+                continue
         if content is None or isinstance(content, str):
             continue
         # Iterate in reverse order to safely remove items while iterating

--- a/maxim/logger/parsers/generation_parser.py
+++ b/maxim/logger/parsers/generation_parser.py
@@ -21,8 +21,8 @@ def parse_function_call(function_call_data):
     Returns:
         The parsed function call.
     """
-    validate_type(function_call_data.get("name"), str, "name")
-    validate_type(function_call_data.get("arguments"), str, "arguments")
+    validate_type(function_call_data.name, str, "name")
+    validate_type(function_call_data.arguments, str, "arguments")
     return function_call_data
 
 
@@ -36,9 +36,9 @@ def parse_tool_calls(tool_calls_data):
     Returns:
         The parsed tool calls.
     """
-    validate_type(tool_calls_data.get("id"), str, "id")
-    validate_type(tool_calls_data.get("type"), str, "type")
-    parse_function_call(tool_calls_data.get("function"))
+    validate_type(tool_calls_data.id, str, "id")
+    validate_type(tool_calls_data.type, str, "type")
+    parse_function_call(tool_calls_data.function)
     return tool_calls_data
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1978,7 +1978,7 @@ wheels = [
 
 [[package]]
 name = "maxim-py"
-version = "3.9.10"
+version = "3.9.12"
 source = { editable = "." }
 dependencies = [
     { name = "filetype" },


### PR DESCRIPTION
- Fixes type issues where some types like `ChatMessageToolCall` and `ChatMessageToolCallDelta` were breaking during validation
- Adds a `try-except` block around the `json.dumps` to handle non JSON parseable strings
- renamed the `DateTimeEncoder` to `CustomEncoder` and added some more object type supports