### PR TITLE
Fix BaseTool import for backward compatibility with older crewai versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <img src="https://cdn.getmaxim.ai/third-party/sdk.png">
 </div>
 
-This is Python SDK for enabling Maxim observability. [Maxim](https://www.getmaxim.ai?ref=npm) is an enterprise grade evaluation and observability platform.
+This is Python SDK for enabling Maxim observability. [Maxim](https://www.getmaxim.ai) is an enterprise grade evaluation and observability platform.
 
 ## How to integrate
 
@@ -45,14 +45,12 @@ See [cookbook/agno_agent.py](cookbook/agno_agent.py) for an example of tracing a
 | ---------- | ----------- | -------- | ----------------- |
 | ✅         | ✅          | ⛔️      | ⛔️               |
 
-
 ### LiveKit (Alpha)
 
-| Provider | Audio | ToolCalls | Video | 
-| ---------- | ---------- | ----------- | -------- 
-| OpenAI (RealtimeAPI)  | ✅         | ⛔️          | ⛔️      
-| Gemini (RealtimeAPI)  | ✅         | ⛔️          | ⛔️      
-
+| Provider             | Audio | ToolCalls | Video |
+| -------------------- | ----- | --------- | ----- |
+| OpenAI (RealtimeAPI) | ✅    | ⛔️       | ⛔️   |
+| Gemini (RealtimeAPI) | ✅    | ⛔️       | ⛔️   |
 
 # Setting up this repository
 
@@ -61,6 +59,10 @@ See [cookbook/agno_agent.py](cookbook/agno_agent.py) for an example of tracing a
 3. Run `uv sync`.
 
 ## Version changelog
+
+### 3.9.14
+
+- chore: Import fixes for crewai integration.
 
 ### 3.9.13
 
@@ -95,7 +97,7 @@ See [cookbook/agno_agent.py](cookbook/agno_agent.py) for an example of tracing a
 
 ### 3.9.6
 
-- improvement: Increased connection pool max size to 20 for more connections at high throughput. 
+- improvement: Increased connection pool max size to 20 for more connections at high throughput.
 - improvement: Moves network stack from requests to httpx for better stability
 
 ### 3.9.5
@@ -116,7 +118,7 @@ See [cookbook/agno_agent.py](cookbook/agno_agent.py) for an example of tracing a
 
 ### 3.9.1
 
-- fix: Fixes `enable_prompt_management` method bug. 
+- fix: Fixes `enable_prompt_management` method bug.
 
 ### 3.9.0
 
@@ -127,7 +129,7 @@ See [cookbook/agno_agent.py](cookbook/agno_agent.py) for an example of tracing a
 
 ### 3.8.5
 
-- chore: Adds session_id and room_id 
+- chore: Adds session_id and room_id
 
 ### 3.8.4
 
@@ -165,6 +167,7 @@ See [cookbook/agno_agent.py](cookbook/agno_agent.py) for an example of tracing a
 - feat: LiveKit one line integration (alpha)
 
 ### 3.7.1
+
 - fix: Signal registration only happens if the current thread is main thread
 
 ### 3.7.0
@@ -376,7 +379,7 @@ See [cookbook/agno_agent.py](cookbook/agno_agent.py) for an example of tracing a
 - feat: Adds new flow to trigger test runs via Python SDK
 - fix: Minor bug fixes
 
-### v3.0.1 [Breaking changes](https://www.getmaxim.ai/docs/sdk/upgrading-to-v3)
+### v3.0.1 [Breaking changes](https://www.getmaxim.ai/docs/sdk/python/upgrading-to-v3)
 
 - beta release
 - feat: New decorators support for tracing, langchain and langgraph
@@ -405,7 +408,7 @@ See [cookbook/agno_agent.py](cookbook/agno_agent.py) for an example of tracing a
 
 ### v3.0.0rc1
 
-- Check [upgrade steps](https://www.getmaxim.ai/docs/sdk/upgrading-to-v3)
+- Check [upgrade steps](https://www.getmaxim.ai/docs/sdk/python/upgrading-to-v3)
 - feat: Adds new decorators flow to simplify tracing
 - chore: apiKey and baseUrl parameters in MaximConfig are now api_key and base_url respectively.
 

--- a/maxim/logger/crewai/client.py
+++ b/maxim/logger/crewai/client.py
@@ -9,7 +9,12 @@ from typing import Union
 
 from crewai import LLM, Agent, Crew, Flow, Task
 from crewai.agents.agent_builder.base_agent import BaseAgent
-from crewai.tools.agent_tools import BaseTool
+
+try:
+    from crewai.tools import BaseTool
+except ImportError:
+    # Backward compatibility for older versions
+    from crewai.tools.agent_tools.agent_tools import BaseTool
 
 from ...logger import (
     Generation,
@@ -167,6 +172,7 @@ def instrument_crewai(maxim_logger: Logger, debug: bool = False):
 
             global _global_maxim_trace
             global _task_span_ids
+            global _last_llm_usages
 
             # Combine args and kwargs into a dictionary for processing
             bound_args = {}
@@ -725,7 +731,6 @@ def instrument_crewai(maxim_logger: Logger, debug: bool = False):
             if generation:
                 # Create a structured result compatible with GenerationResult
                 # Retrieve usage data captured by the callback
-                global _last_llm_usages  # Ensure access to the global
 
                 prompt_tokens = 0
                 completion_tokens = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "maxim-py"
-version = "3.9.13"
+version = "3.9.14"
 description = "A package that allows you to use the Maxim Python Library to interact with the Maxim Platform."
 readme = "README.md"
 requires-python = ">=3.9.20"


### PR DESCRIPTION
Fixed CrewAI import compatibility and global variable access

This PR addresses two issues in the CrewAI instrumentation:

1. Added backward compatibility for importing `BaseTool` from different locations depending on the CrewAI version:
   - Tries to import from the newer location `crewai.tools`
   - Falls back to the older location `crewai.tools.agent_tools.agent_tools` if the first import fails

2. Fixed a missing global declaration for `_last_llm_usages` by:
   - Moving the global declaration to the beginning of the function where other globals are declared
   - Removing the redundant global declaration and comment that was previously in the generation handling section

These changes ensure the instrumentation works correctly across different versions of CrewAI and properly tracks LLM usage metrics.