### PR TITLE
[Maxim-py]: Add simulation support to VariableMappingInput

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,11 @@ On `generation.result` events, the callback is invoked with a payload containing
 
 ## Version changelog
 
+### 3.14.13
+
+- feat: Adds `simulation_meta` and `simulation_output` to `variable_mappings` in `yields_output`
+
+
 ### 3.14.12
 
 - feat: Adds `yields_output_with_tracing` to link logs with test runs

--- a/maxim/models/test_run.py
+++ b/maxim/models/test_run.py
@@ -224,9 +224,9 @@ class SimulationMeta:
             result["stopReason"] = self.stop_reason
         if self.usage is not None:
             result["usage"] = {
-                "promptTokens": self.usage.prompt_tokens,
-                "completionTokens": self.usage.completion_tokens,
-                "totalTokens": self.usage.total_tokens,
+                "prompt_tokens": self.usage.prompt_tokens,
+                "completion_tokens": self.usage.completion_tokens,
+                "total_tokens": self.usage.total_tokens,
                 **({"latency": self.usage.latency} if self.usage.latency is not None else {}),
             }
         if self.cost is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "maxim-py"
-version = "3.14.12"
+version = "3.14.13"
 description = "A package that allows you to use the Maxim Python Library to interact with the Maxim Platform."
 readme = "README.md"
 requires-python = ">=3.9.20"


### PR DESCRIPTION
This pull request adds simulation support to the `VariableMappingInput` class for handling multi-turn conversation evaluations. 

**Key Changes:**
- Added `simulation_outputs` field to store outputs from each simulation turn
- Added `simulation_meta` field to store full simulation metadata including messages, usage, and cost information
- Enhanced the `get()` method to retrieve simulation-related fields by key
- Updated `to_dict()` method to include simulation fields in the output
- Modified `from_yielded_output()` to extract simulation data from output objects and prioritize conversation history from simulation metadata over standard output messages
- Improved documentation to clarify that `messages` represents conversation history for simulation contexts

These changes enable platform evaluators to access detailed simulation data during variable mapping operations.