### PR TITLE
[Maxim PY] Mirrors on_llm_start input message setting in on_chat_model_start in Langchain tracer

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ On `generation.result` events, the callback is invoked with a payload containing
 
 ## Version changelog
 
+### 3.14.15
+
+- fix: sets last input as user message in Langchain tracer's `on_chat_model_start`
+
 ### 3.14.14
 
 - feat: Adds response format support in generation result

--- a/maxim/logger/langchain/tracer.py
+++ b/maxim/logger/langchain/tracer.py
@@ -403,6 +403,12 @@ class MaximLangchainTracer(BaseCallbackHandler):
                 self.container_manager.set_container(str(run_id), container)
                 if isinstance(container, TraceContainer):
                     self.container_manager.set_root_trace(str(run_id), container)
+            # Set trace input from last user message like JS tracer
+            try:
+                if isinstance(container, TraceContainer) and last_input_message:
+                    container.set_input(last_input_message)
+            except Exception:
+                pass
             generation_container = container.add_generation(generation_config)
             if len(attachments) > 0:
                 for attachment in attachments:

--- a/maxim/tests/test_logger_langchain_03x.py
+++ b/maxim/tests/test_logger_langchain_03x.py
@@ -1325,6 +1325,43 @@ class TestLoggingUsingLangchain(unittest.TestCase):
 
         logger.flush()
 
+    def test_multi_turn_chat_conversation(self):
+        """Two-turn chat: second invoke includes prior human/assistant messages as history.
+
+        Mirrors a typical app that calls the model once per user message while passing
+        the full transcript (or rolling window) on each request.
+        """
+        logger = self.maxim.logger(LoggerConfig(id=repoId))
+        model = ChatOpenAI(
+            callbacks=[MaximLangchainTracer(logger)],
+            api_key=openAIKey,
+            model="gpt-4o-mini",
+        )
+
+        first_messages = [
+            (
+                "system",
+                "You are a concise assistant. Reply in one short sentence when possible.",
+            ),
+            ("human", "Remember this secret word exactly: zebra."),
+        ]
+        first = model.invoke(first_messages)
+        print(f"Multi-turn first reply: {first}")
+
+        second_messages = [
+            (
+                "system",
+                "You are a concise assistant. Reply in one short sentence when possible.",
+            ),
+            ("human", "Remember this secret word exactly: zebra."),
+            ("ai", first.content),
+            ("human", "What secret word did I ask you to remember? Reply with that word only."),
+        ]
+        second = model.invoke(second_messages)
+        print(f"Multi-turn second reply: {second}")
+
+        logger.flush()
+
     def tearDown(self) -> None:
         self.maxim.cleanup()
         return super().tearDown()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "maxim-py"
-version = "3.14.14"
+version = "3.14.15"
 description = "A package that allows you to use the Maxim Python Library to interact with the Maxim Platform."
 readme = "README.md"
 requires-python = ">=3.9.20"


### PR DESCRIPTION
### TL;DR

Fixed Langchain tracer to set the last user message as trace input in `on_chat_model_start` method

### What changed?

Added logic in the Langchain tracer's `on_chat_model_start` method to extract the last user message from the input and set it as the trace input, matching the behavior of the JavaScript tracer. The change includes error handling to gracefully handle any exceptions during this process.

### How to test?

Run the new test `test_multi_turn_chat_conversation` which simulates a two-turn chat conversation where the second invoke includes prior human/assistant messages as history. This test verifies that the tracer correctly handles multi-turn conversations and sets the appropriate trace input.

### Why make this change?

This ensures consistency between the Python and JavaScript tracers by properly capturing the user's input message as the trace input, rather than leaving it unset. This is particularly important for multi-turn conversations where the full message history is passed but only the latest user message should be considered the primary input for tracing purposes.