### PR TITLE
[Maxim-py]: Add test config preset support with `with_preset` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ On `generation.result` events, the callback is invoked with a payload containing
 
 ## Version changelog
 
+### 3.14.16
+
+- feat: Adds option to use test config presets from platform for test runs using `with_preset`
+
 ### 3.14.15
 
 - fix: sets last input as user message in Langchain tracer's `on_chat_model_start`

--- a/maxim/apis/maxim_apis.py
+++ b/maxim/apis/maxim_apis.py
@@ -39,6 +39,7 @@ from ..models import (
     HumanEvaluationConfig,
     ImageURL,
     LocalExecutionResponse,
+    Preset,
     PromptResponse,
     RunType,
     SignedURLResponse,
@@ -1167,6 +1168,56 @@ class MaximAPI:
         except Exception as e:
             raise Exception(e) from e
 
+    def fetch_preset(self, name: str, workspace_id: str, entity_id: str, entity_type: str) -> Preset:
+        """
+        Fetch a preset (test config) by name for a given entity.
+
+        Args:
+            name: The name of the preset
+            workspace_id: The workspace ID
+            entity_id: The entity ID (workflow, prompt version, or prompt chain version)
+            entity_type: The entity type (PROMPT, WORKFLOW, or PROMPT_CHAIN)
+
+        Returns:
+            Preset: The preset details
+
+        Raises:
+            Exception: If the preset is not found or the request fails
+        """
+        try:
+            from urllib.parse import quote
+            params = (
+                f"name={quote(name)}"
+                f"&workspaceId={workspace_id}"
+                f"&entityId={entity_id}"
+                f"&entityType={entity_type}"
+            )
+            res = self.__make_network_call(
+                method="GET",
+                endpoint=f"/api/sdk/v1/test-configs?{params}",
+            )
+            json_response = json.loads(res.decode())
+            if "error" in json_response:
+                raise Exception(json_response["error"])
+            return Preset.dict_to_class(json_response["data"])
+        except httpx.HTTPStatusError as e:
+            if e.response is not None:
+                try:
+                    error_data = e.response.json()
+                    if (
+                        error_data
+                        and isinstance(error_data, dict)
+                        and "error" in error_data
+                        and isinstance(error_data["error"], dict)
+                        and "message" in error_data["error"]
+                    ):
+                        raise Exception(error_data["error"]["message"]) from e
+                except (ValueError, KeyError):
+                    pass
+            raise Exception(e) from e
+        except Exception as e:
+            raise Exception(e) from e
+
     def create_test_run(
         self,
         name: str,
@@ -1181,6 +1232,7 @@ class MaximAPI:
         human_evaluation_config: Optional[HumanEvaluationConfig] = None,
         simulation_config: Optional[SimulationConfig] = None,
         connected_repo_id: Optional[str] = None,
+        test_config_id: Optional[str] = None,
     ) -> TestRun:
         """
         Create a new test run.
@@ -1245,6 +1297,11 @@ class MaximAPI:
                             "connectedRepoId": (
                                 connected_repo_id
                                 if connected_repo_id is not None
+                                else None
+                            ),
+                            "testConfigId": (
+                                test_config_id
+                                if test_config_id is not None
                                 else None
                             ),
                         }.items()

--- a/maxim/models/__init__.py
+++ b/maxim/models/__init__.py
@@ -93,6 +93,10 @@ from .test_run import (
     YieldedOutputMeta,
     YieldedOutputCost,
     YieldedOutputTokenUsage,
+    Preset,
+    PresetDataset,
+    PresetEvaluator,
+    ContextToEvaluateEntry,
 )
 
 __all__ = [

--- a/maxim/models/evaluator.py
+++ b/maxim/models/evaluator.py
@@ -25,6 +25,7 @@ class Evaluator:
     builtin: bool
     reversed: Optional[bool] = False
     config: Optional[Any] = None
+    meta: Optional[Dict[str, Any]] = None
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -36,6 +37,7 @@ class Evaluator:
                 "builtin": self.builtin,
                 "reversed": self.reversed,
                 "config": self.config,
+                "meta": self.meta,
             }.items()
             if v is not None
         }
@@ -48,6 +50,7 @@ class Evaluator:
             "builtin": self.builtin,
             "reversed": self.reversed,
             "config": self.config,
+            "meta": self.meta,
         }
 
     @classmethod
@@ -59,6 +62,7 @@ class Evaluator:
             builtin=data["builtin"],
             reversed=data.get("reversed"),
             config=data.get("config"),
+            meta=data.get("meta"),
         )
 
 

--- a/maxim/models/test_run.py
+++ b/maxim/models/test_run.py
@@ -429,7 +429,7 @@ class TestRun:
             workspace_id=data["workspaceId"],
             eval_config=data["evalConfig"],
             human_evaluation_config=(
-                HumanEvaluationConfig(data["humanEvaluationConfig"])
+                HumanEvaluationConfig(**data["humanEvaluationConfig"])
                 if data.get("humanEvaluationConfig")
                 else None
             ),
@@ -1161,6 +1161,85 @@ class SimulationContext:
     turn_number: int
     total_cost: float
     total_tokens: int
+
+
+@dataclass
+class PresetDataset:
+    """A dataset attached to a preset."""
+    id: str
+    name: str
+    split_id: Optional[str] = None
+    split_name: Optional[str] = None
+
+    @classmethod
+    def dict_to_class(cls, data: Dict[str, Any]) -> "PresetDataset":
+        return cls(
+            id=data["id"],
+            name=data["name"],
+            split_id=data.get("splitId"),
+            split_name=data.get("splitName"),
+        )
+
+
+@dataclass
+class PresetEvaluator:
+    """An evaluator attached to a preset."""
+    id: str
+    name: str
+    meta: Optional[Dict[str, Any]] = None
+
+    @classmethod
+    def dict_to_class(cls, data: Dict[str, Any]) -> "PresetEvaluator":
+        return cls(
+            id=data["id"],
+            name=data["name"],
+            meta=data.get("meta"),
+        )
+
+
+@dataclass
+class ContextToEvaluateEntry:
+    """A context-to-evaluate configuration entry from a preset."""
+    type: str
+    payload: str
+
+    @classmethod
+    def dict_to_class(cls, data: Dict[str, Any]) -> "ContextToEvaluateEntry":
+        return cls(type=data["type"], payload=data["payload"])
+
+
+@dataclass
+class Preset:
+    """A test configuration preset (TestConfig) fetched from the platform."""
+    id: str
+    name: str
+    description: Optional[str] = None
+    datasets: Optional[List[PresetDataset]] = None
+    evaluators: Optional[List[PresetEvaluator]] = None
+    simulation_config: Optional[SimulationConfig] = None
+    context_to_evaluate: Optional[List[ContextToEvaluateEntry]] = None
+    attached_data_sources: Optional[List[Dict[str, str]]] = None
+
+    @classmethod
+    def dict_to_class(cls, data: Dict[str, Any]) -> "Preset":
+        return cls(
+            id=data["id"],
+            name=data["name"],
+            description=data.get("description"),
+            datasets=[PresetDataset.dict_to_class(d) for d in (data.get("datasets") or [])] or None,
+            evaluators=[PresetEvaluator.dict_to_class(e) for e in (data.get("evaluators") or [])] or None,
+            simulation_config=(
+                SimulationConfig.dict_to_class(data["simulationConfig"])
+                if data.get("simulationConfig")
+                else None
+            ),
+            context_to_evaluate=(
+                [ContextToEvaluateEntry.dict_to_class(c) for c in (data.get("contextToEvaluate") or [])]
+                if data.get("contextToEvaluate")
+                else None
+            ),
+            attached_data_sources=data.get("attachedDataSources"),
+        )
 
 
 @dataclass

--- a/maxim/test_runs/test_run_builder.py
+++ b/maxim/test_runs/test_run_builder.py
@@ -4,6 +4,7 @@ import math
 import re
 import threading
 import time
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Dict, Generic, List, Optional, Union, final
 from uuid import uuid4
@@ -35,6 +36,7 @@ from ..models import (
 )
 from ..models.dataset import Data, LocalData
 from ..models.evaluator import (
+    EvaluatorType,
     LocalEvaluationResultWithId,
     LocalEvaluatorResultParameter,
     PlatformEvaluator,
@@ -45,6 +47,7 @@ from ..models.test_run import (
     ExecuteSimulationPromptForDataResponse,
     ExecuteSimulationWorkflowForDataResponse,
     LocalExecutionResponse,
+    Preset,
     PromptChainVersionConfig,
     PromptVersionConfig,
     SimulationConfig,
@@ -148,6 +151,7 @@ class TestRunBuilder(Generic[T]):
             in_workspace_id=workspace_id,
         )
         self._maxim_apis = MaximAPI(base_url, api_key)
+        self._preset_name: Optional[str] = None
 
     def _compute_sdk_variables_for_platform_evaluators(
         self,
@@ -1096,6 +1100,31 @@ class TestRunBuilder(Generic[T]):
         self._config.simulation_config = simulation_config
         return self
 
+    def with_preset(self, preset_name: str) -> "TestRunBuilder[T]":
+        """
+        Set a preset (test configuration) to use for this test run.
+
+        The preset provides default values for datasets, evaluators, simulation config,
+        and context-to-evaluate settings. Any values explicitly set via other builder
+        methods will take priority over preset defaults.
+
+        Requires an entity to be set first via with_workflow_id(), with_prompt_version_id(),
+        or with_prompt_chain_version_id(), as the preset is scoped to a specific entity.
+
+        Args:
+            preset_name (str): The name of the preset (test config) in the workspace
+
+        Returns:
+            TestRunBuilder[T]: The current TestRunBuilder instance for method chaining
+
+        Raises:
+            ValueError: If preset_name is empty or not a string
+        """
+        if not preset_name or not isinstance(preset_name, str):
+            raise ValueError("Preset name must be a non-empty string.")
+        self._preset_name = preset_name
+        return self
+
     def yields_output(
         self,
         output_function: Callable[
@@ -1328,29 +1357,57 @@ class TestRunBuilder(Generic[T]):
                         self._config.simulation_config is not None
                         and self._config.output_function is not None
                     )
-                    self._maxim_apis.push_test_run_entry(
-                        test_run=test_run,
-                        entry=result.entry,
-                        run_config=(
-                            None if is_local_sim else (
-                                {
-                                    "cost": (
-                                        result.meta.cost.to_dict()
-                                        if result.meta.cost is not None
-                                        else None
-                                    ),
-                                    "usage": (
-                                        result.meta.usage.to_dict()
-                                        if result.meta.usage is not None
-                                        else None
-                                    ),
-                                }
-                                if result.meta is not None
-                                else None
-                            )
-                        ),
-                        local_simulation=is_local_sim or None,
+                    # For simulation endpoint entries (simulation_config set, no output_function),
+                    is_simulation_endpoint_entry = (
+                        self._config.simulation_config is not None
+                        and self._config.output_function is None
+                        and self._config.output_function_with_tracing is None
                     )
+                    has_local_eval_results = (
+                        result.entry.local_evaluation_results is not None
+                        and len(result.entry.local_evaluation_results) > 0
+                    )
+                    should_push = not is_simulation_endpoint_entry or has_local_eval_results
+
+                    if should_push:
+                        # For simulation endpoint entries with local results: filter evalConfig
+                        # to only local evaluators so the V4 push fast path marks COMPLETE
+                        # without re-queuing for platform evals (which the simulation worker already ran).
+                        push_test_run = test_run
+                        if is_simulation_endpoint_entry:
+                            push_test_run = deepcopy(test_run)
+                            if "evals" in push_test_run.eval_config:
+                                push_test_run.eval_config = {
+                                    **push_test_run.eval_config,
+                                    "evals": [
+                                        e for e in push_test_run.eval_config["evals"]
+                                        if e.get("type") == EvaluatorType.LOCAL.value
+                                    ],
+                                }
+
+                        self._maxim_apis.push_test_run_entry(
+                            test_run=push_test_run,
+                            entry=result.entry,
+                            run_config=(
+                                None if is_local_sim else (
+                                    {
+                                        "cost": (
+                                            result.meta.cost.to_dict()
+                                            if result.meta.cost is not None
+                                            else None
+                                        ),
+                                        "usage": (
+                                            result.meta.usage.to_dict()
+                                            if result.meta.usage is not None
+                                            else None
+                                        ),
+                                    }
+                                    if result.meta is not None
+                                    else None
+                                )
+                            ),
+                            local_simulation=is_local_sim or None,
+                        )
                 else:
                     # Check if we have platform evaluators with variable_mapping
                     has_platform_evaluator_with_mapping = any(
@@ -1667,33 +1724,57 @@ class TestRunBuilder(Generic[T]):
                         self._config.simulation_config is not None
                         and self._config.output_function is not None
                     )
-                    self._maxim_apis.push_test_run_entry(
-                        test_run=TestRunWithDatasetEntry(
+                    is_simulation_endpoint_entry = (
+                        self._config.simulation_config is not None
+                        and self._config.output_function is None
+                        and self._config.output_function_with_tracing is None
+                    )
+                    has_local_eval_results = (
+                        result.entry.local_evaluation_results is not None
+                        and len(result.entry.local_evaluation_results) > 0
+                    )
+                    should_push = not is_simulation_endpoint_entry or has_local_eval_results
+
+                    if should_push:
+                        push_test_run_with_dataset = TestRunWithDatasetEntry(
                             test_run=test_run,
                             dataset_id=dataset_id,
                             dataset_entry_id=row.id,
-                        ),
-                        entry=result.entry,
-                        run_config=(
-                            None if is_local_sim else (
-                                {
-                                    "cost": (
-                                        result.meta.cost.to_dict()
-                                        if result.meta.cost is not None
-                                        else None
-                                    ),
-                                    "usage": (
-                                        result.meta.usage.to_dict()
-                                        if result.meta.usage is not None
-                                        else None
-                                    ),
+                        )
+                        if is_simulation_endpoint_entry:
+                            push_test_run_with_dataset = deepcopy(push_test_run_with_dataset)
+                            if "evals" in push_test_run_with_dataset.eval_config:
+                                push_test_run_with_dataset.eval_config = {
+                                    **push_test_run_with_dataset.eval_config,
+                                    "evals": [
+                                        e for e in push_test_run_with_dataset.eval_config["evals"]
+                                        if e.get("type") == EvaluatorType.LOCAL.value
+                                    ],
                                 }
-                                if result.meta
-                                else None
-                            )
-                        ),
-                        local_simulation=is_local_sim or None,
-                    )
+
+                        self._maxim_apis.push_test_run_entry(
+                            test_run=push_test_run_with_dataset,
+                            entry=result.entry,
+                            run_config=(
+                                None if is_local_sim else (
+                                    {
+                                        "cost": (
+                                            result.meta.cost.to_dict()
+                                            if result.meta.cost is not None
+                                            else None
+                                        ),
+                                        "usage": (
+                                            result.meta.usage.to_dict()
+                                            if result.meta.usage is not None
+                                            else None
+                                        ),
+                                    }
+                                    if result.meta
+                                    else None
+                                )
+                            ),
+                            local_simulation=is_local_sim or None,
+                        )
                 else:
                     # Check if we have platform evaluators with variable_mapping
                     has_platform_evaluator_with_mapping = any(
@@ -1950,6 +2031,63 @@ class TestRunBuilder(Generic[T]):
         )
         thread.start()
 
+    def _resolve_preset(self, preset: Preset) -> None:
+        """
+        Merge preset defaults into the current config.
+        Explicit config always takes priority over preset values.
+        """
+        # 1. Dataset: only if user hasn't called with_data()
+        if self._config.data is None and preset.datasets and len(preset.datasets) > 0:
+            ds = preset.datasets[0]
+            if ds.split_id:
+                self._config.data = ds.split_id
+            else:
+                self._config.data = ds.id
+            if len(preset.datasets) > 1:
+                self._config.logger.info(
+                    message=f"Preset '{preset.name}' has {len(preset.datasets)} datasets; using '{ds.name}'. "
+                    "Override with .with_data() to select a different dataset."
+                )
+
+        # 2. Evaluators: only if user hasn't called with_evaluators()
+        if (not self._config.evaluators or len(self._config.evaluators) == 0) and preset.evaluators:
+            self._config.evaluators = [e.name for e in preset.evaluators]
+
+        # 3. Simulation config: only if user hasn't called with_simulation_config()
+        if self._config.simulation_config is None and preset.simulation_config is not None:
+            sim_config = preset.simulation_config
+            if not self._config.workflow and sim_config.response_fields:
+                sim_config = SimulationConfig(
+                    persona=sim_config.persona,
+                    max_turns=sim_config.max_turns,
+                    tools=sim_config.tools,
+                    context=sim_config.context,
+                    response_fields=None,
+                    environment_id=sim_config.environment_id,
+                    stop_trigger=sim_config.stop_trigger,
+                    additional_instructions=sim_config.additional_instructions,
+                    custom_simulator=sim_config.custom_simulator,
+                )
+            self._config.simulation_config = sim_config
+
+        # 4. Context to evaluate: apply to the user's entity config if not already set
+        if preset.context_to_evaluate:
+            ctx_column = None
+            for entry in preset.context_to_evaluate:
+                if entry.type == "DATASET_COLUMN":
+                    ctx_column = entry.payload
+                    break
+            if ctx_column:
+                if self._config.workflow and not self._config.workflow.context_to_evaluate:
+                    self._config.workflow.context_to_evaluate = ctx_column
+                elif self._config.prompt_version and not self._config.prompt_version.context_to_evaluate:
+                    self._config.prompt_version.context_to_evaluate = ctx_column
+                elif self._config.prompt_chain_version and not self._config.prompt_chain_version.context_to_evaluate:
+                    self._config.prompt_chain_version.context_to_evaluate = ctx_column
+
+        # 5. Store preset ID for backend reference
+        self._config.test_config_id = preset.id
+
     def run(self, timeout_in_minutes: Optional[int] = 10) -> Optional[RunResult]:
         """
         Run the test
@@ -1967,6 +2105,46 @@ class TestRunBuilder(Generic[T]):
                 errors.append("Name is required to run a test.")
             if self._config.in_workspace_id == "":
                 errors.append("Workspace id is required to run a test.")
+            # Resolve preset before remaining validation so preset-supplied
+            # values (dataset, evaluators, simulation config, etc.) are
+            # available for the checks below.
+            if self._preset_name is not None:
+                entity_id = None
+                entity_type = None
+                if self._config.workflow:
+                    entity_id = self._config.workflow.id
+                    entity_type = "WORKFLOW"
+                elif self._config.prompt_version:
+                    entity_id = self._config.prompt_version.id
+                    entity_type = "PROMPT"
+                elif self._config.prompt_chain_version:
+                    entity_id = self._config.prompt_chain_version.id
+                    entity_type = "PROMPT_CHAIN"
+
+                if entity_id is None or entity_type is None:
+                    errors.append(
+                        "with_preset() requires an entity to be set first via "
+                        "with_workflow_id(), with_prompt_version_id(), or with_prompt_chain_version_id()."
+                    )
+                else:
+                    self._config.logger.info(
+                        message=f"Fetching preset '{self._preset_name}' for {entity_type} '{entity_id}'..."
+                    )
+                    try:
+                        preset = self._maxim_apis.fetch_preset(
+                            name=self._preset_name,
+                            workspace_id=self._config.in_workspace_id,
+                            entity_id=entity_id,
+                            entity_type=entity_type,
+                        )
+                        self._resolve_preset(preset)
+                        self._config.logger.info(
+                            message=f"Preset '{self._preset_name}' resolved successfully."
+                        )
+                    except Exception as e:
+                        errors.append(
+                            f"Failed to fetch preset '{self._preset_name}': {str(e)}"
+                        )
             if (
                 self._config.output_function is None
                 and self._config.workflow is None
@@ -2149,6 +2327,7 @@ class TestRunBuilder(Generic[T]):
                     ),
                     simulation_config=simulation_config_to_send,
                     connected_repo_id=self._config.internal_maxim_logger.id if self._config.internal_maxim_logger else None,
+                    test_config_id=self._config.test_config_id,
                 )
                 if self._config.environment_name is not None:
                     test_run.environment_name = self._config.environment_name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "maxim-py"
-version = "3.14.15"
+version = "3.14.16"
 description = "A package that allows you to use the Maxim Python Library to interact with the Maxim Platform."
 readme = "README.md"
 requires-python = ">=3.9.20"


### PR DESCRIPTION
This pull request adds support for using test configuration presets from the platform when creating test runs.

**Key Changes:**

- Added `with_preset()` method to TestRunBuilder that allows specifying a preset name to load test configuration defaults
- Implemented `fetch_preset()` API method to retrieve preset configurations by name, workspace, entity ID, and entity type
- Created new model classes `Preset`, `PresetDataset`, `PresetEvaluator`, and `ContextToEvaluateEntry` to represent preset data structures
- Added preset resolution logic that applies preset defaults for datasets, evaluators, simulation config, and context-to-evaluate settings when explicit values haven't been set
- Enhanced the Evaluator model with an optional `meta` field
- Modified test run creation to include `test_config_id` parameter for backend reference
- Updated entry pushing logic to handle simulation endpoint entries with local evaluation results by filtering to only local evaluators

The preset functionality requires an entity (workflow, prompt version, or prompt chain version) to be set first, as presets are scoped to specific entities. Explicitly configured values always take priority over preset defaults.