### PR TITLE
[Maxim-py]: Fix thinking block duplication in generations

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ On `generation.result` events, the callback is invoked with a payload containing
 
 ## Version changelog
 
+### 3.14.18
+
+- fix: Fixes thinking block duplication in generations.
+
 ### 3.14.17
 
 - feat: Adds support for environment handling in test run's `with_preset` function

--- a/maxim/logger/parsers/generation_parser.py
+++ b/maxim/logger/parsers/generation_parser.py
@@ -360,6 +360,8 @@ def _responses_prepend_thinking_to_message_dict(msg: dict, prefix: str) -> None:
         if block.get("type") == "output_text":
             t = block.get("text")
             if isinstance(t, str):
+                if t.startswith(prefix):
+                    return
                 block["text"] = prefix + t
             else:
                 block["text"] = prefix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "maxim-py"
-version = "3.14.17" 
+version = "3.14.18"
 description = "A package that allows you to use the Maxim Python Library to interact with the Maxim Platform."
 readme = "README.md"
 requires-python = ">=3.9.20"


### PR DESCRIPTION
Fixes an issue where thinking blocks were being duplicated in generations. The `_responses_prepend_thinking_to_message_dict` function now checks if the text already starts with the thinking prefix before prepending it, preventing repeated application of the prefix to the same block.