### PR TITLE
fix: memory leak fixes in Langchain tracer

### DIFF
--- a/maxim/logger/langchain/tracer.py
+++ b/maxim/logger/langchain/tracer.py
@@ -467,20 +467,30 @@ class MaximLangchainTracer(BaseCallbackHandler):
             self.logger.generation_result(str(run_id), result)
             # Call generation.result callback
             generation_container = self.generation_container_store.get(str(run_id))
-            if generation_container is not None and self.callback is not None:
-                generation_id = str(run_id)
-                generation_name = getattr(generation_container, "_name", None)
-                token_usage = result.get("usage", {})
-                self.callback(
-                    "generation.result",
-                    {
-                        "generation_id": generation_id,
-                        "generation_name": generation_name,
-                        "token_usage": token_usage,
-                    },
-                )
-                # Clean up the store entry to prevent leaks
-                self.generation_container_store.delete(str(run_id))
+            if generation_container is not None:
+                try:
+                    if self.callback is not None:
+                        generation_id = str(run_id)
+                        generation_name = getattr(generation_container, "_name", None)
+                        token_usage = result.get("usage", {})
+                        self.callback(
+                            "generation.result",
+                            {
+                                "generation_id": generation_id,
+                                "generation_name": generation_name,
+                                "token_usage": token_usage,
+                            },
+                        )
+                except Exception as e:
+                    # The callback is user-supplied; a failure in it must not skip
+                    # the cleanup below (or the container/evaluator cleanup after).
+                    scribe().warning(
+                        "[MaximSDK] generation.result callback raised: %s", e
+                    )
+                finally:
+                    # Clean up the store entry to prevent leaks, whether or not a
+                    # callback is configured and whether or not it raised.
+                    self.generation_container_store.delete(str(run_id))
             # Remove mapping for this run_id when top-level (do not end here)
             if container.parent() is None:
                 self.container_manager.remove_run_id_mapping(str(run_id))
@@ -499,9 +509,9 @@ class MaximLangchainTracer(BaseCallbackHandler):
                 except Exception:
                     pass
             # check if need to attach evaluator
-            if self.to_be_evaluated_container_store.get(str(run_id)):
-                obj = self.to_be_evaluated_container_store.get(str(run_id))
-                if obj:
+            obj = self.to_be_evaluated_container_store.get(str(run_id))
+            if obj:
+                try:
                     generation_container: Generation = obj["generation_container"]
                     output = None
                     tool_call_name = None
@@ -539,6 +549,9 @@ class MaximLangchainTracer(BaseCallbackHandler):
                     generation_container.evaluate().with_evaluators(
                         *obj["evaluators"]
                     ).with_variables(variable_dict)
+                finally:
+                    # Clean up the store entry to prevent leaks
+                    self.to_be_evaluated_container_store.delete(str(run_id))
         except Exception as e:
             import traceback
 
@@ -790,15 +803,37 @@ class MaximLangchainTracer(BaseCallbackHandler):
             if container is None:
                 scribe().error("[MaximSDK] Couldn't find a container for chain")
                 return
-            chain_error = parse_langchain_llm_error(error)
-            container.add_error(
-                {
-                    "id": str(run_id),
-                    "message": chain_error.message,
-                    "type": chain_error.type,
-                    "code": chain_error.code,
-                }
-            )
+            try:
+                chain_error = parse_langchain_llm_error(error)
+                container.add_error(
+                    {
+                        "id": str(run_id),
+                        "message": chain_error.message,
+                        "type": chain_error.type,
+                        "code": chain_error.code,
+                    }
+                )
+            finally:
+                # Clean up the run_id mapping to prevent leaks, symmetric with
+                # on_chain_end. This runs even if parsing or add_error fails.
+                # Failures below surface via the outer handler rather than being
+                # silently swallowed.
+                self.container_manager.remove_run_id_mapping(str(run_id))
+                # If this is a top-level chain (no parent), also end the root trace
+                if parent_run_id is None:
+                    parent_container = self.container_manager.pop_root_trace(
+                        str(run_id)
+                    )
+                    if parent_container is not None:
+                        parent_container.end()
+                        if self.callback is not None:
+                            self.callback(
+                                "trace.ended",
+                                {
+                                    "trace_id": parent_container.id(),
+                                    "trace_name": parent_container.name(),
+                                },
+                            )
         except Exception as e:
             import traceback
 

--- a/maxim/logger/langchain/utils.py
+++ b/maxim/logger/langchain/utils.py
@@ -337,7 +337,9 @@ def parse_langchain_generation_chunk(generation: GenerationChunk):
 
 def parse_langchain_text_generation(generation: Generation):
     choices = []
-    messages = parse_langchain_messages([generation.text], "system")
+    # parse_langchain_messages returns a (messages, attachments) tuple; text
+    # generations carry no attachments so we only need the messages list.
+    messages, _ = parse_langchain_messages([generation.text], "system")
     if len(messages) > 0:
         for i, message in enumerate(messages):
             choices.append(

--- a/maxim/logger/models/container.py
+++ b/maxim/logger/models/container.py
@@ -4,6 +4,7 @@ This module contains data models used for tracking and logging LangChain operati
 including metadata storage and run information.
 """
 
+import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
@@ -535,6 +536,15 @@ class SessionContainer(Container):
         self._logger.session_end(self._id)
 
 
+# Backstop TTL (seconds) after which a run_id mapping is considered abandoned
+# and swept. This is only a safety net for runs whose terminal callback
+# (on_*_end / on_*_error) never fires - e.g. a cancelled stream or a client
+# disconnect. It is refreshed on every access, so genuinely active (even very
+# long-running) traces are never evicted. Set generously to avoid dropping a
+# slow-but-live run. 2 hours.
+CONTAINER_MAPPING_TTL = 60 * 60 * 2
+
+
 class ContainerManager:
     """
     Manages mapping between LangChain run IDs and Maxim containers (trace/span).
@@ -542,29 +552,69 @@ class ContainerManager:
     This mirrors the behavior of the JS ContainerManager used by the Maxim LangChain tracer,
     ensuring we never overwrite a parent trace container mapping with a child span container
     and allowing proper lifecycle management.
+
+    Each mapping is timestamped so that runs which never reach a terminal callback
+    (cancelled streams, client disconnects, exceptions raised inside LangChain before
+    the end event) cannot accumulate indefinitely. Timestamps are refreshed on access
+    and expired entries are swept on writes.
     """
 
-    def __init__(self) -> None:
-        # Map a run_id (as string) to its current container (TraceContainer or SpanContainer)
-        self._run_id_to_container: dict[str, Container] = {}
-        # Track top-level root trace containers keyed by the originating run_id (no parent)
-        self._root_run_id_to_trace: dict[str, TraceContainer] = {}
+    def __init__(self, ttl_seconds: int = CONTAINER_MAPPING_TTL) -> None:
+        # Map a run_id (as string) to (container, last_touched_epoch)
+        self._run_id_to_container: dict[str, tuple[Container, float]] = {}
+        # Track top-level root trace containers keyed by run_id -> (trace, last_touched_epoch)
+        self._root_run_id_to_trace: dict[str, tuple[TraceContainer, float]] = {}
+        self._ttl_seconds = ttl_seconds
+
+    def _sweep_expired(self) -> None:
+        """Remove mappings that have not been touched within the TTL window."""
+        cutoff = time.time() - self._ttl_seconds
+        expired_runs = [
+            run_id
+            for run_id, (_, touched) in self._run_id_to_container.items()
+            if touched < cutoff
+        ]
+        for run_id in expired_runs:
+            del self._run_id_to_container[run_id]
+        expired_roots = [
+            run_id
+            for run_id, (_, touched) in self._root_run_id_to_trace.items()
+            if touched < cutoff
+        ]
+        for run_id in expired_roots:
+            del self._root_run_id_to_trace[run_id]
 
     def get_container(self, run_id: str) -> Optional[Container]:
-        return self._run_id_to_container.get(run_id)
+        entry = self._run_id_to_container.get(run_id)
+        if entry is None:
+            return None
+        container, _ = entry
+        # Refresh the timestamp so active runs are never swept.
+        self._run_id_to_container[run_id] = (container, time.time())
+        return container
 
     def set_container(self, run_id: str, container: Container) -> None:
-        self._run_id_to_container[run_id] = container
+        self._run_id_to_container[run_id] = (container, time.time())
+        self._sweep_expired()
 
     def remove_run_id_mapping(self, run_id: str) -> None:
-        if run_id in self._run_id_to_container:
-            _ = self._run_id_to_container.pop(run_id)
+        self._run_id_to_container.pop(run_id, None)
 
     def set_root_trace(self, run_id: str, trace_container: TraceContainer) -> None:
-        self._root_run_id_to_trace[run_id] = trace_container
+        self._root_run_id_to_trace[run_id] = (trace_container, time.time())
+        self._sweep_expired()
 
     def get_root_trace(self, run_id: str) -> Optional[TraceContainer]:
-        return self._root_run_id_to_trace.get(run_id)
+        entry = self._root_run_id_to_trace.get(run_id)
+        if entry is None:
+            return None
+        trace_container, _ = entry
+        self._root_run_id_to_trace[run_id] = (trace_container, time.time())
+        return trace_container
 
     def pop_root_trace(self, run_id: str) -> Optional[TraceContainer]:
-        return self._root_run_id_to_trace.pop(run_id, None)
+        entry = self._root_run_id_to_trace.pop(run_id, None)
+        if entry is None:
+            return None
+        trace_container, _ = entry
+        return trace_container

--- a/maxim/logger/parsers/generation_parser.py
+++ b/maxim/logger/parsers/generation_parser.py
@@ -1,5 +1,10 @@
+import datetime
+import decimal
 import enum
 import json
+import pathlib
+import types
+import uuid
 from typing import Any, Dict, List, Optional
 
 # A bit of workaround to make sure there are no breakages when openai is not installed
@@ -219,13 +224,69 @@ def default_json_serializer(o: Any) -> Any:
     """
     if isinstance(o, enum.Enum):
         return o.value
-    if hasattr(o, "to_dict"):
+    # Read-only dict wrappers (e.g. a class' __dict__) are not JSON serializable
+    # by default.
+    if isinstance(o, types.MappingProxyType):
+        return dict(o)
+    # Classes must be handled before the instance-method branches below, since
+    # those methods exist on the class as unbound functions and would raise if
+    # called without an instance. A model *class* is how structured-output
+    # formats are usually declared (e.g. response_format=MyModel), and its
+    # schema is the meaningful representation.
+    if isinstance(o, type):
+        # pydantic v2 model class
+        if callable(getattr(o, "model_json_schema", None)):
+            return o.model_json_schema()
+        # pydantic v1 model class
+        if callable(getattr(o, "schema", None)):
+            return o.schema()
+        return {"type": o.__name__}
+    if isinstance(o, (datetime.datetime, datetime.date, datetime.time)):
+        return o.isoformat()
+    if isinstance(o, datetime.timedelta):
+        return o.total_seconds()
+    if isinstance(o, decimal.Decimal):
+        return float(o)
+    if isinstance(o, uuid.UUID):
+        return str(o)
+    if isinstance(o, pathlib.PurePath):
+        return str(o)
+    if isinstance(o, (set, frozenset)):
+        return list(o)
+    if isinstance(o, (bytes, bytearray)):
+        return o.decode("utf-8", errors="replace")
+    if callable(getattr(o, "to_dict", None)):
         return o.to_dict()
+    # Pydantic v2 model instances expose model_dump().
+    if callable(getattr(o, "model_dump", None)):
+        return o.model_dump()
+    # numpy scalars and arrays (duck-typed, so numpy stays an optional import).
+    # tolist() covers both and returns native python types.
+    if callable(getattr(o, "tolist", None)):
+        return o.tolist()
+    # Functions and exceptions would otherwise fall through to vars() and
+    # serialize as a misleading empty dict, so describe them instead.
+    if isinstance(
+        o, (types.FunctionType, types.BuiltinFunctionType, types.MethodType)
+    ):
+        return {"type": getattr(o, "__name__", "function")}
+    if isinstance(o, BaseException):
+        return {"type": type(o).__name__, "message": str(o)}
 
     try:
         return vars(o)
     except TypeError:
         pass
+
+    # Objects using __slots__ have no __dict__, so vars() above fails on them.
+    slots: List[str] = []
+    for klass in type(o).__mro__:
+        klass_slots = getattr(klass, "__slots__", ())
+        if isinstance(klass_slots, str):
+            klass_slots = (klass_slots,)
+        slots.extend(klass_slots)
+    if slots:
+        return {s: getattr(o, s) for s in slots if hasattr(o, s)}
 
     raise TypeError(f"Object of type {o.__class__.__name__} is not JSON serializable")
 

--- a/maxim/tests/test_generation_parser_serializer.py
+++ b/maxim/tests/test_generation_parser_serializer.py
@@ -1,0 +1,311 @@
+import datetime
+import decimal
+import enum
+import json
+import pathlib
+import types
+import unittest
+import uuid
+
+from pydantic import BaseModel
+
+from maxim.logger.parsers.generation_parser import (
+    default_json_serializer,
+    parse_model_parameters,
+)
+
+
+class Weather(BaseModel):
+    temp: float
+    city: str
+
+
+class Color(enum.Enum):
+    RED = "red"
+    BLUE = "blue"
+
+
+class HasToDict:
+    def to_dict(self):
+        return {"kind": "to_dict"}
+
+
+class HasModelDump:
+    def model_dump(self):
+        return {"kind": "model_dump"}
+
+
+class PlainObject:
+    def __init__(self):
+        self.a = 1
+        self.b = "two"
+
+
+class TestDefaultJsonSerializer(unittest.TestCase):
+    """Unit tests for the fallback serializer used by json.dumps."""
+
+    def test_mapping_proxy_becomes_dict(self):
+        mp = types.MappingProxyType({"type": "json_schema", "n": 1})
+        self.assertEqual(
+            default_json_serializer(mp), {"type": "json_schema", "n": 1}
+        )
+
+    def test_enum_returns_value(self):
+        self.assertEqual(default_json_serializer(Color.RED), "red")
+
+    def test_to_dict_is_preferred(self):
+        self.assertEqual(default_json_serializer(HasToDict()), {"kind": "to_dict"})
+
+    def test_model_dump_is_used(self):
+        self.assertEqual(
+            default_json_serializer(HasModelDump()), {"kind": "model_dump"}
+        )
+
+    def test_pydantic_model_class_returns_json_schema(self):
+        # A model *class* must not hit the model_dump() branch, which would
+        # call an unbound method and raise.
+        result = default_json_serializer(Weather)
+        self.assertIsInstance(result, dict)
+        self.assertEqual(sorted(result["properties"].keys()), ["city", "temp"])
+
+    def test_pydantic_model_instance_still_uses_model_dump(self):
+        self.assertEqual(
+            default_json_serializer(Weather(temp=1.0, city="x")),
+            {"temp": 1.0, "city": "x"},
+        )
+
+    def test_plain_class_is_named_not_raised(self):
+        result = default_json_serializer(PlainObject)
+        self.assertEqual(result, {"type": "PlainObject"})
+
+    def test_class_with_non_callable_schema_attr_falls_through(self):
+        # A non-pydantic class may carry an attribute of the same name that is
+        # not callable; it must not be invoked.
+        class NotAModel:
+            model_json_schema = {"not": "callable"}
+
+        self.assertEqual(default_json_serializer(NotAModel), {"type": "NotAModel"})
+
+    def test_set_becomes_list(self):
+        self.assertEqual(sorted(default_json_serializer({"a", "b"})), ["a", "b"])
+
+    def test_frozenset_becomes_list(self):
+        self.assertEqual(
+            sorted(default_json_serializer(frozenset({"a", "b"}))), ["a", "b"]
+        )
+
+    def test_bytes_are_decoded(self):
+        self.assertEqual(default_json_serializer(b"hello"), "hello")
+
+    def test_bytearray_is_decoded(self):
+        self.assertEqual(default_json_serializer(bytearray(b"hi")), "hi")
+
+    def test_invalid_utf8_bytes_are_replaced_not_raised(self):
+        # \xff is not valid utf-8; should decode to the Unicode replacement
+        # character rather than raising.
+        result = default_json_serializer(b"\xff")
+        self.assertIsInstance(result, str)
+        self.assertEqual(result, "�")
+
+    def test_plain_object_falls_back_to_vars(self):
+        self.assertEqual(
+            default_json_serializer(PlainObject()), {"a": 1, "b": "two"}
+        )
+
+    def test_unserializable_object_raises_type_error(self):
+        with self.assertRaises(TypeError):
+            # a raw class' __dict__ contains C-level descriptors
+            default_json_serializer(object())
+
+
+class TestStdlibScalarTypes(unittest.TestCase):
+    """Common stdlib types that json.dumps cannot serialize natively."""
+
+    def test_datetime_is_isoformat(self):
+        self.assertEqual(
+            default_json_serializer(datetime.datetime(2026, 7, 16, 12, 0)),
+            "2026-07-16T12:00:00",
+        )
+
+    def test_date_is_isoformat(self):
+        self.assertEqual(
+            default_json_serializer(datetime.date(2026, 7, 16)), "2026-07-16"
+        )
+
+    def test_time_is_isoformat(self):
+        self.assertEqual(default_json_serializer(datetime.time(12, 30)), "12:30:00")
+
+    def test_timedelta_is_seconds(self):
+        self.assertEqual(
+            default_json_serializer(datetime.timedelta(seconds=30)), 30.0
+        )
+
+    def test_decimal_becomes_float(self):
+        self.assertEqual(default_json_serializer(decimal.Decimal("1.5")), 1.5)
+
+    def test_uuid_becomes_string(self):
+        u = uuid.uuid4()
+        self.assertEqual(default_json_serializer(u), str(u))
+
+    def test_path_becomes_string(self):
+        self.assertEqual(default_json_serializer(pathlib.Path("/tmp/x")), "/tmp/x")
+
+
+class TestObjectShapes(unittest.TestCase):
+    """Objects whose natural fallback would be lossy or wrong."""
+
+    def test_slotted_object_uses_slots(self):
+        class Slotted:
+            __slots__ = ("a", "b")
+
+            def __init__(self):
+                self.a = 1
+                self.b = 2
+
+        # vars() raises on __slots__ objects; must fall back to slot names.
+        self.assertEqual(default_json_serializer(Slotted()), {"a": 1, "b": 2})
+
+    def test_string_slots_are_handled(self):
+        class OneSlot:
+            __slots__ = "a"  # a bare string, not a tuple
+
+            def __init__(self):
+                self.a = 1
+
+        self.assertEqual(default_json_serializer(OneSlot()), {"a": 1})
+
+    def test_function_is_named_not_empty_dict(self):
+        def a_tool(city: str) -> str:
+            return city
+
+        # vars(fn) is {}, which would log misleading empty data.
+        self.assertEqual(default_json_serializer(a_tool), {"type": "a_tool"})
+
+    def test_exception_is_described_not_empty_dict(self):
+        self.assertEqual(
+            default_json_serializer(ValueError("bad")),
+            {"type": "ValueError", "message": "bad"},
+        )
+
+    def test_numpy_like_scalar_uses_tolist(self):
+        # duck-typed so numpy stays an optional dependency
+        class FakeScalar:
+            def tolist(self):
+                return 5
+
+        self.assertEqual(default_json_serializer(FakeScalar()), 5)
+
+    def test_numpy_like_array_uses_tolist(self):
+        class FakeArray:
+            def tolist(self):
+                return [1, 2, 3]
+
+        self.assertEqual(default_json_serializer(FakeArray()), [1, 2, 3])
+
+
+class TestNotConsumedOrGuessed(unittest.TestCase):
+    """Values that must stay skipped rather than be coerced."""
+
+    def test_generator_param_is_not_consumed(self):
+        # Consuming a generator to log it would exhaust it and break the
+        # caller's real API call. Skipping is the correct behaviour.
+        gen = (i for i in range(3))
+        parse_model_parameters({"g": gen})
+        self.assertEqual(list(gen), [0, 1, 2])
+
+    def test_circular_reference_is_skipped_not_raised(self):
+        class Circular:
+            def __init__(self):
+                self.self_ref = self
+
+        out = parse_model_parameters({"c": Circular(), "model": "gpt-4"})
+        self.assertNotIn("c", out)
+        self.assertEqual(out["model"], "gpt-4")
+
+    def test_raising_to_dict_is_skipped_not_raised(self):
+        class Boom:
+            def to_dict(self):
+                raise RuntimeError("boom")
+
+        out = parse_model_parameters({"b": Boom(), "model": "gpt-4"})
+        self.assertNotIn("b", out)
+        self.assertEqual(out["model"], "gpt-4")
+
+
+class TestParseModelParameters(unittest.TestCase):
+    """Unit tests for parse_model_parameters end-to-end behaviour."""
+
+    def test_none_returns_empty_dict(self):
+        self.assertEqual(parse_model_parameters(None), {})
+
+    def test_none_values_are_dropped(self):
+        out = parse_model_parameters({"a": None, "b": 1})
+        self.assertNotIn("a", out)
+        self.assertIn("b", out)
+
+    def test_string_values_pass_through_unchanged(self):
+        out = parse_model_parameters({"model": "gpt-4"})
+        self.assertEqual(out["model"], "gpt-4")
+
+    def test_non_string_values_are_json_stringified(self):
+        out = parse_model_parameters({"temperature": 0.7})
+        self.assertEqual(out["temperature"], "0.7")
+
+    def test_mapping_proxy_response_format_is_serialized(self):
+        # Regression: previously skipped with a warning because a mappingproxy
+        # (e.g. response_format passed as a class/proxy) is not JSON serializable.
+        mp = types.MappingProxyType(
+            {"type": "json_schema", "json_schema": {"name": "resp"}}
+        )
+        out = parse_model_parameters({"response_format": mp})
+        self.assertIn("response_format", out)
+        self.assertEqual(
+            json.loads(out["response_format"]),
+            {"type": "json_schema", "json_schema": {"name": "resp"}},
+        )
+
+    def test_pydantic_model_class_response_format_is_serialized(self):
+        # Regression: response_format=MyModel is the usual way structured output
+        # is declared. vars() on the class yields a mappingproxy, which produced
+        # the original "Object of type mappingproxy is not JSON serializable".
+        out = parse_model_parameters({"response_format": Weather, "model": "gpt-4"})
+        self.assertIn("response_format", out)
+        self.assertEqual(
+            sorted(json.loads(out["response_format"])["properties"].keys()),
+            ["city", "temp"],
+        )
+
+    def test_nested_values_are_serialized(self):
+        # Nested is the common real shape; the serializer is applied recursively.
+        out = parse_model_parameters(
+            {
+                "meta": {
+                    "at": datetime.datetime(2026, 1, 1),
+                    "cost": decimal.Decimal("2.5"),
+                    "tags": ["a"],
+                }
+            }
+        )
+        self.assertEqual(
+            json.loads(out["meta"]),
+            {"at": "2026-01-01T00:00:00", "cost": 2.5, "tags": ["a"]},
+        )
+
+    def test_set_value_is_serialized(self):
+        out = parse_model_parameters({"stop": {"a", "b"}})
+        self.assertIn("stop", out)
+        self.assertEqual(sorted(json.loads(out["stop"])), ["a", "b"])
+
+    def test_bytes_value_is_serialized(self):
+        out = parse_model_parameters({"blob": b"hello"})
+        self.assertEqual(json.loads(out["blob"]), "hello")
+
+    def test_unserializable_value_is_skipped_not_raised(self):
+        # Value that cannot be represented is skipped, other keys survive.
+        out = parse_model_parameters({"bad": object(), "model": "gpt-4"})
+        self.assertNotIn("bad", out)
+        self.assertEqual(out["model"], "gpt-4")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/maxim/tests/test_logger_langchain_03x.py
+++ b/maxim/tests/test_logger_langchain_03x.py
@@ -446,7 +446,7 @@ class TestLoggingUsingLangchain(unittest.TestCase):
         logger = self.maxim.logger(LoggerConfig(id=repoId))
         model = AnthropicLLM(
             api_key=anthropicApiKey,
-            model_name="claude-3-5-sonnet-20240620",
+            model_name="claude-sonnet-5",
             callbacks=[MaximLangchainTracer(logger)],
         )
         messages = [
@@ -465,7 +465,7 @@ class TestLoggingUsingLangchain(unittest.TestCase):
         model = ChatAnthropic(
             api_key=anthropicApiKey,
             callbacks=[MaximLangchainTracer(logger)],
-            model_name="claude-3-5-sonnet-20240620",
+            model_name="claude-sonnet-5",
             timeout=10,
             stop=None,
         )
@@ -485,7 +485,7 @@ class TestLoggingUsingLangchain(unittest.TestCase):
         model = ChatAnthropic(
             api_key=anthropicApiKey,
             callbacks=[MaximLangchainTracer(logger)],
-            model_name="claude-3-5-sonnet-20240620",
+            model_name="claude-sonnet-5",
             timeout=10,
             stop=None,
             stream_usage=True,
@@ -571,7 +571,7 @@ class TestLoggingUsingLangchain(unittest.TestCase):
         model = ChatAnthropic(
             api_key=anthropicApiKey,
             callbacks=[MaximLangchainTracer(logger)],
-            model_name="claude-3-5-sonnet-20240620",
+            model_name="claude-sonnet-5",
             timeout=10,
             stop=None,
         )
@@ -592,7 +592,7 @@ class TestLoggingUsingLangchain(unittest.TestCase):
         model = ChatAnthropic(
             api_key=anthropicApiKey,
             callbacks=[MaximLangchainTracer(logger)],
-            model_name="claude-3-sonnet-20240229",
+            model_name="claude-sonnet-5",
             timeout=10,
             stop=None,
         )
@@ -612,7 +612,7 @@ class TestLoggingUsingLangchain(unittest.TestCase):
         model = ChatAnthropic(
             api_key=anthropicApiKey,
             callbacks=[MaximLangchainTracer(logger)],
-            model_name="claude-3-haiku-20240307",
+            model_name="claude-haiku-4-5",
             timeout=10,
             stop=None,
         )
@@ -1080,7 +1080,7 @@ class TestLoggingUsingLangchain(unittest.TestCase):
         model = ChatOpenAI(
             callbacks=[tracer],
             api_key=openAIKey,
-            model="gpt-3.5-turbo",
+            model="gpt-4o-mini",
             temperature=0,
         )
 


### PR DESCRIPTION
### TL;DR

Fixes memory leaks in the LangChain tracer by ensuring store entries are always cleaned up, adds TTL-based eviction to `ContainerManager`, and properly handles chain errors at the top level.

### What changed?

- `on_llm_end`: The `generation_container_store` entry is now deleted regardless of whether a callback is configured, preventing leaks when no callback is set. The `to_be_evaluated_container_store` entry is now cleaned up in a `finally` block, ensuring it is always removed even if an exception occurs during evaluator attachment. The redundant double-lookup of `to_be_evaluated_container_store` was also simplified.

- `on_chain_error`: Top-level chain errors now properly clean up the `run_id` mapping and end the root trace container, mirroring the behavior of `on_chain_end`. Previously, a chain error at the root level would leave the trace open and the mapping dangling.

- `ContainerManager`: Each mapping now stores a `(container, last_touched_epoch)` tuple. Timestamps are refreshed on every read, and a sweep of expired entries (default TTL: 2 hours) runs on every write. This prevents abandoned mappings from accumulating when terminal callbacks (`on_*_end` / `on_*_error`) never fire due to cancelled streams or client disconnects.

- `parse_langchain_text_generation`: Fixed unpacking of the `(messages, attachments)` tuple returned by `parse_langchain_messages`, discarding the unused attachments value.

- Test model names updated to current Anthropic and OpenAI model identifiers (`claude-sonnet-5`, `claude-haiku-4-5`, `gpt-4o-mini`).

### How to test?

- Run the existing LangChain tracer test suite (`test_logger_langchain_03x.py`) to verify end-to-end tracing still works correctly with the updated model names.
- Simulate a chain error at the root level and confirm the trace is ended and the callback receives a `trace.ended` event.
- Verify that after `on_llm_end` completes, neither `generation_container_store` nor `to_be_evaluated_container_store` retain entries for the completed run.
- Instantiate a `ContainerManager`, add entries, advance time past the TTL, trigger a write, and assert the expired entries are gone.

### Why make this change?

Long-running or high-throughput applications accumulate entries in the various in-memory stores whenever terminal callbacks fail to fire (cancelled streams, exceptions, client disconnects). Over time this causes unbounded memory growth. Additionally, chain errors at the root level were leaving traces permanently open, producing incomplete data in Maxim. The TTL sweep provides a safety net without affecting genuinely active traces, since timestamps are refreshed on every access.