### PR TITLE
chore: version bump and readme change

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,15 @@ On `generation.result` events, the callback is invoked with a payload containing
 
 ## Version changelog
 
+### 3.14.20
+
+- fix: Fixes `mappingproxy` serialization errors in log payloads by unifying scalar handling across both log serializers
+- fix: Compacts `modelParameters` serialization - class references now serialize as type names instead of full JSON schemas, and duplicated structured-output schemas are collapsed (~10x smaller generation payloads)
+- fix: Fixes remaining container and generation store leaks in `MaximLangchainTracer` for runs passing `session_id` metadata; adds missing `on_retriever_error` handler and root trace cleanup on tool and retriever runs
+- fix: Bounds log writer memory when the backend is slower than the log rate by spilling overflow batches to disk and replaying them later (no logs are dropped)
+- fix: Hardens spilled log replay - unique spill filenames, quarantine of persistently failing files as `.failed`, and `raise_exceptions` now propagates replay failures
+- feat: Adds `MAXIM_CONTAINER_MAPPING_TTL_SECONDS` and `MAXIM_GENERATION_STORE_TTL_SECONDS` env variables to tune the idle-container cleanup TTL (default raised to 1 hour, refreshed on activity so long-running traces are never swept mid-run)
+
 ### 3.14.19
 
 - fix: adds robust handling for generation parser for different types

--- a/maxim/env_config.py
+++ b/maxim/env_config.py
@@ -1,0 +1,46 @@
+"""
+Helpers for reading numeric tuning knobs from the environment.
+
+These are operational backstops (cache TTLs, retention windows) that a very
+small number of deployments need to override - e.g. workloads with legitimately
+long-idle, human-in-the-loop traces. They are read lazily at construction time,
+not import time, so a test or an embedding application can set them before the
+component that reads them is created.
+"""
+
+import os
+from typing import Optional
+
+from .scribe import scribe
+
+
+def env_int(name: str, default: int, minimum: int = 1) -> int:
+    """
+    Read a positive integer from environment variable ``name``.
+
+    Falls back to ``default`` when the variable is unset, empty, non-numeric,
+    or below ``minimum``. A malformed override is warned about rather than
+    raised, so a bad env value can never take a logging integration down.
+    """
+    raw: Optional[str] = os.environ.get(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        value = int(raw.strip())
+    except (TypeError, ValueError):
+        scribe().warning(
+            "[MaximSDK] %s=%r is not an integer; using default %s.",
+            name,
+            raw,
+            default,
+        )
+        return default
+    if value < minimum:
+        scribe().warning(
+            "[MaximSDK] %s=%s is below the minimum of %s; using minimum.",
+            name,
+            value,
+            minimum,
+        )
+        return minimum
+    return value

--- a/maxim/logger/components/types.py
+++ b/maxim/logger/components/types.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional, TypedDict, Union
 from typing_extensions import deprecated
 
 from ...scribe import scribe
+from ..parsers.json_safe import UNHANDLED, json_safe_scalar
 
 
 class Entity(Enum):
@@ -33,28 +34,46 @@ class CustomEncoder(json.JSONEncoder):
     """
 
     def default(self, o):
-        # Handle datetime objects
-        if isinstance(o, datetime):
-            return o.isoformat()
+        # Scalar conversions are shared with default_json_serializer. Keeping
+        # them in one place is what stops a type from being handled on the
+        # model-parameter path but raising here, on the payload path that every
+        # log line passes through - the shape of the original
+        # "Object of type mappingproxy is not JSON serializable" report.
+        converted = json_safe_scalar(o)
+        if converted is not UNHANDLED:
+            return converted
+
+        # Classes must be handled before the instance-method branches below.
+        # Those methods exist on the class as unbound functions, so calling
+        # them without an instance raises; and vars() of a class returns a
+        # mappingproxy, which used to re-enter default() and fail. A class in a
+        # payload is a type reference, not content, so name it.
+        if isinstance(o, type):
+            return {"type": o.__name__}
 
         # Handle any object with model_dump (newer Pydantic)
-        if hasattr(o, "model_dump") and callable(o.model_dump):
+        if callable(getattr(o, "model_dump", None)):
             return o.model_dump()
 
         # Handle any object with dict (older Pydantic)
-        if hasattr(o, "dict") and callable(o.dict):
+        if callable(getattr(o, "dict", None)):
             return o.dict()
 
         # Handle any object with to_dict
-        if hasattr(o, "to_dict") and callable(o.to_dict):
+        if callable(getattr(o, "to_dict", None)):
             return o.to_dict()
 
         # Handle any object with __dict__
+        #
+        # Unlike default_json_serializer, which records unknown objects by type
+        # name, this encoder expands them. It serializes the log payload -
+        # messages, results, metadata - where the object *is* the content, and
+        # collapsing a message to its type name would empty the log.
         if hasattr(o, "__dict__"):
             return vars(o)
 
         # Handle any object with _asdict (namedtuples)
-        if hasattr(o, "_asdict") and callable(o._asdict):
+        if callable(getattr(o, "_asdict", None)):
             return o._asdict()
 
         return super().default(o)

--- a/maxim/logger/langchain/tracer.py
+++ b/maxim/logger/langchain/tracer.py
@@ -29,6 +29,7 @@ from ...logger import (
     ToolCallConfigDict,
     ToolCallErrorDict,
 )
+from ...env_config import env_int
 from ...scribe import scribe
 from ..__init__ import Generation
 from ..models import Container, Metadata, SpanContainer, TraceContainer
@@ -42,8 +43,20 @@ from .utils import (
     parse_langchain_provider,
 )
 
-# 20 minutes
-DEFAULT_TIMEOUT = 60 * 20
+# Retention for the generation and to-be-evaluated stores. These hold a
+# Generation between its start and end callbacks so the `generation.result`
+# event can be emitted and any evaluator attached. Unlike the container TTL
+# this is an absolute expiry from the start callback (it is not refreshed), so
+# it must exceed the longest single generation for the result callback to still
+# fire. One hour by default, matching the container TTL; overridable via
+# MAXIM_GENERATION_STORE_TTL_SECONDS.
+GENERATION_STORE_TTL_ENV = "MAXIM_GENERATION_STORE_TTL_SECONDS"
+DEFAULT_GENERATION_STORE_TTL = 60 * 60
+
+
+def _default_generation_store_ttl() -> int:
+    return env_int(GENERATION_STORE_TTL_ENV, DEFAULT_GENERATION_STORE_TTL, minimum=1)
+
 
 tracer_callback_type = Callable[[str, Any], None]
 
@@ -80,6 +93,8 @@ class MaximLangchainTracer(BaseCallbackHandler):
             ExpiringKeyValueStore()
         )
         self.generation_container_store: ExpiringKeyValueStore = ExpiringKeyValueStore()
+        # Read once per tracer so the env override is picked up at construction.
+        self._generation_store_ttl: int = _default_generation_store_ttl()
         self.metadata: Union[dict[str, Any], None] = None
         self.eval_config: Union[dict[str, list[str]], None] = eval_config
         self.callback: Union[tracer_callback_type, None] = callback
@@ -238,6 +253,41 @@ class MaximLangchainTracer(BaseCallbackHandler):
                 container = trace_container
         return container
 
+    def __release_top_level_run(
+        self, run_id: UUID, parent_run_id: Optional[UUID] = None
+    ) -> None:
+        """
+        Releases the container mapping registered for a top-level run and ends
+        its trace.
+
+        Cleanup is keyed on `parent_run_id is None` - i.e. "did this run create
+        the mapping" - and never on `container.parent()`. A trace created with
+        a session_id has a non-None parent while still being the run that owns
+        the mapping, so gating on the container's parent leaked every mapping
+        for anyone passing metadata={"maxim": {"session_id": ...}}, which is the
+        common shape for a chat application.
+
+        Removal uses the same key the registration used, so this is a no-op for
+        child runs, whose container belongs to the parent and must outlive them.
+        """
+        if parent_run_id is not None:
+            return
+        self.container_manager.remove_run_id_mapping(str(run_id))
+        root = self.container_manager.pop_root_trace(str(run_id))
+        if root is None:
+            return
+        root.end()
+        if self.callback is not None:
+            try:
+                self.callback(
+                    "trace.ended",
+                    {"trace_id": root.id(), "trace_name": root.name()},
+                )
+            except Exception as e:
+                # User-supplied callback; its failure must not propagate now
+                # that the mapping has already been released.
+                scribe().warning("[MaximSDK] trace.ended callback raised: %s", e)
+
     def __get_metadata(
         self, metadata: Optional[Dict[str, Any]] = None
     ) -> Optional[Metadata]:
@@ -301,7 +351,11 @@ class MaximLangchainTracer(BaseCallbackHandler):
                 return
             if not container.is_created():
                 container.create()
-            if container.parent() is None:
+            # Register under this run_id only when this run is the top-level
+            # one, so that registration and teardown use the same key and the
+            # same condition. Gating on container.parent() instead registered a
+            # parent's container under a child's run_id.
+            if parent_run_id is None:
                 self.container_manager.set_container(str(run_id), container)
                 if isinstance(container, TraceContainer):
                     self.container_manager.set_root_trace(str(run_id), container)
@@ -314,7 +368,7 @@ class MaximLangchainTracer(BaseCallbackHandler):
             generation_container = container.add_generation(generation_config)
             # Store generation container for callback
             self.generation_container_store.set(
-                str(run_id), generation_container, DEFAULT_TIMEOUT
+                str(run_id), generation_container, self._generation_store_ttl
             )
             if len(attachments) > 0:
                 for attachment in attachments:
@@ -338,7 +392,7 @@ class MaximLangchainTracer(BaseCallbackHandler):
                     "input": last_input_message,
                 }
                 self.to_be_evaluated_container_store.set(
-                    str(generation_container.id), eval_data, DEFAULT_TIMEOUT
+                    str(generation_container.id), eval_data, self._generation_store_ttl
                 )
         except Exception as e:
             import traceback
@@ -362,6 +416,7 @@ class MaximLangchainTracer(BaseCallbackHandler):
             scribe().debug("[MaximSDK: Langchain] on_chat_model_start called")
             self._parse_metadata(metadata)
             run_id = kwargs.get("run_id", None)
+            parent_run_id = kwargs.get("parent_run_id", None)
             model, model_parameters = parse_langchain_model_parameters(**kwargs)
             provider = parse_langchain_provider(serialized)
             model, provider = parse_langchain_model_and_provider(model, provider)
@@ -391,7 +446,7 @@ class MaximLangchainTracer(BaseCallbackHandler):
                     "tags": maxim_metadata.generation_tags if maxim_metadata else None,
                 }
             )
-            container = self.__get_container(run_id, kwargs.get("parent_run_id", None))
+            container = self.__get_container(run_id, parent_run_id)
             if container is None:
                 scribe().error(
                     "[MaximSDK][on_chat_model_start] Couldn't find a container for generation]"
@@ -399,7 +454,11 @@ class MaximLangchainTracer(BaseCallbackHandler):
                 return
             if not container.is_created():
                 container.create()
-            if container.parent() is None:
+            # Register under this run_id only when this run is the top-level
+            # one, so that registration and teardown use the same key and the
+            # same condition. Gating on container.parent() instead registered a
+            # parent's container under a child's run_id.
+            if parent_run_id is None:
                 self.container_manager.set_container(str(run_id), container)
                 if isinstance(container, TraceContainer):
                     self.container_manager.set_root_trace(str(run_id), container)
@@ -415,7 +474,7 @@ class MaximLangchainTracer(BaseCallbackHandler):
                     generation_container.add_attachment(attachment)
             # Store generation container for callback
             self.generation_container_store.set(
-                str(run_id), generation_container, DEFAULT_TIMEOUT
+                str(run_id), generation_container, self._generation_store_ttl
             )
             # checking if we need to attach evaluator
             if (
@@ -436,7 +495,7 @@ class MaximLangchainTracer(BaseCallbackHandler):
                     "input": last_input_message,
                 }
                 self.to_be_evaluated_container_store.set(
-                    str(generation_container.id), eval_data, DEFAULT_TIMEOUT
+                    str(generation_container.id), eval_data, self._generation_store_ttl
                 )
         except Exception as e:
             import traceback
@@ -452,9 +511,9 @@ class MaximLangchainTracer(BaseCallbackHandler):
 
     def on_llm_end(self, response: LLMResult, **kwargs: Any) -> Any:
         """Run when LLM ends running."""
+        run_id = kwargs.get("run_id", None)
         try:
             scribe().debug("[MaximSDK][Langchain] on_llm_end called")
-            run_id = kwargs.get("run_id", None)
             parent_run_id = kwargs.get("parent_run_id", None)
             result = parse_langchain_llm_result(response)
             container = self.__get_container(run_id, parent_run_id)
@@ -491,23 +550,7 @@ class MaximLangchainTracer(BaseCallbackHandler):
                     # Clean up the store entry to prevent leaks, whether or not a
                     # callback is configured and whether or not it raised.
                     self.generation_container_store.delete(str(run_id))
-            # Remove mapping for this run_id when top-level (do not end here)
-            if container.parent() is None:
-                self.container_manager.remove_run_id_mapping(str(run_id))
-                try:
-                    root = self.container_manager.pop_root_trace(str(run_id))
-                    if root is not None:
-                        root.end()
-                        if self.callback is not None:
-                            self.callback(
-                                "trace.ended",
-                                {
-                                    "trace_id": root.id(),
-                                    "trace_name": root.name(),
-                                },
-                            )
-                except Exception:
-                    pass
+            self.__release_top_level_run(run_id, parent_run_id)
             # check if need to attach evaluator
             obj = self.to_be_evaluated_container_store.get(str(run_id))
             if obj:
@@ -560,14 +603,23 @@ class MaximLangchainTracer(BaseCallbackHandler):
                 e,
                 traceback.format_exc(),
             )
+        finally:
+            # Both stores hold a live Generation (and the input text) and are
+            # keyed by run_id, so they must be released on every exit from this
+            # handler - including the early return when no container is found,
+            # and any exception raised before the cleanup above is reached.
+            # Deletes are idempotent, so repeating them here is harmless.
+            if run_id is not None:
+                self.generation_container_store.delete(str(run_id))
+                self.to_be_evaluated_container_store.delete(str(run_id))
 
     def on_llm_error(
         self, error: Union[Exception, BaseException, KeyboardInterrupt], **kwargs: Any
     ) -> Any:
         """Run when LLM errors."""
+        run_id = kwargs.get("run_id", None)
         try:
             scribe().debug("[MaximSDK] on_llm_error called")
-            run_id = kwargs.get("run_id", None)
             parent_run_id = kwargs.get("parent_run_id", None)
             container = self.__get_container(run_id, parent_run_id)
             if container is None:
@@ -577,25 +629,7 @@ class MaximLangchainTracer(BaseCallbackHandler):
                 return
             generation_error = parse_langchain_llm_error(error)
             self.logger.generation_error(str(run_id), generation_error)
-            # Clean up generation container store to prevent leaks
-            self.generation_container_store.delete(str(run_id))
-            # Remove mapping for this run_id when top-level (do not end here)
-            if container.parent() is None:
-                self.container_manager.remove_run_id_mapping(str(run_id))
-                try:
-                    root = self.container_manager.pop_root_trace(str(run_id))
-                    if root is not None:
-                        root.end()
-                        if self.callback is not None:
-                            self.callback(
-                                "trace.ended",
-                                {
-                                    "trace_id": root.id(),
-                                    "trace_name": root.name(),
-                                },
-                            )
-                except Exception:
-                    pass
+            self.__release_top_level_run(run_id, parent_run_id)
         except Exception as e:
             import traceback
 
@@ -604,6 +638,13 @@ class MaximLangchainTracer(BaseCallbackHandler):
                 e,
                 traceback.format_exc(),
             )
+        finally:
+            # Symmetric with on_llm_end. The evaluator store was previously
+            # never cleaned on the error path at all, retaining a Generation
+            # and the input text for every failed call.
+            if run_id is not None:
+                self.generation_container_store.delete(str(run_id))
+                self.to_be_evaluated_container_store.delete(str(run_id))
 
     def on_retriever_start(
         self,
@@ -656,13 +697,57 @@ class MaximLangchainTracer(BaseCallbackHandler):
                 return
             documents_list: List[str] = [doc.page_content for doc in documents]
             self.logger.retrieval_output(str(run_id), documents_list)
-            if container.parent() is None:
-                self.container_manager.remove_run_id_mapping(str(run_id))
+            # Previously this removed the run_id mapping but never popped the
+            # root trace, so a retriever-rooted run leaked one entry in
+            # _root_run_id_to_trace and left the trace permanently open.
+            self.__release_top_level_run(run_id, parent_run_id)
         except Exception as e:
             import traceback
 
             scribe().error(
                 "[MaximSDK] Failed to process retriever-end: %s\n%s",
+                e,
+                traceback.format_exc(),
+            )
+
+    def on_retriever_error(
+        self,
+        error: Union[Exception, BaseException, KeyboardInterrupt],
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """
+        Run when Retriever errors.
+
+        Without this handler a failing retriever - a vector store timeout is
+        the common case - had no terminal callback at all, so the container and
+        root trace registered by on_retriever_start were never released.
+        """
+        try:
+            scribe().debug("[MaximSDK] on_retriever_error called")
+            container = self.__get_container(run_id, parent_run_id)
+            if container is None:
+                scribe().error("[MaximSDK] Couldn't find a container for retrieval")
+                return
+            try:
+                retrieval_error = parse_langchain_llm_error(error)
+                container.add_error(
+                    {
+                        "id": str(run_id),
+                        "message": retrieval_error.message,
+                        "type": retrieval_error.type,
+                        "code": retrieval_error.code,
+                    }
+                )
+            finally:
+                self.__release_top_level_run(run_id, parent_run_id)
+        except Exception as e:
+            import traceback
+
+            scribe().error(
+                "[MaximSDK] Failed to process retriever-error: %s\n%s",
                 e,
                 traceback.format_exc(),
             )
@@ -921,8 +1006,10 @@ class MaximLangchainTracer(BaseCallbackHandler):
                     }
                 )
             )
-            if container.parent() is None:
+            if parent_run_id is None:
                 self.container_manager.set_container(str(run_id), container)
+                if isinstance(container, TraceContainer):
+                    self.container_manager.set_root_trace(str(run_id), container)
         except Exception as e:
             import traceback
 
@@ -971,8 +1058,7 @@ class MaximLangchainTracer(BaseCallbackHandler):
                         str(run_id), output.get("content", None)
                     )
 
-            if container.parent() is None:
-                self.container_manager.remove_run_id_mapping(str(run_id))
+            self.__release_top_level_run(run_id, parent_run_id)
         except Exception as e:
             import traceback
 
@@ -987,7 +1073,8 @@ class MaximLangchainTracer(BaseCallbackHandler):
     ) -> Any:
         try:
             run_id = kwargs.get("run_id", None)
-            container = self.__get_container(run_id, kwargs.get("parent_run_id", None))
+            parent_run_id = kwargs.get("parent_run_id", None)
+            container = self.__get_container(run_id, parent_run_id)
             if container is None:
                 scribe().error("[MaximSDK] Couldn't find a container for tool_call")
                 return
@@ -996,8 +1083,7 @@ class MaximLangchainTracer(BaseCallbackHandler):
                     str(run_id),
                     ToolCallErrorDict({"message": str(error), "code": "", "type": ""}),
                 )
-            if container.parent() is None:
-                self.container_manager.remove_run_id_mapping(str(run_id))
+            self.__release_top_level_run(run_id, parent_run_id)
         except Exception as e:
             import traceback
 

--- a/maxim/logger/models/container.py
+++ b/maxim/logger/models/container.py
@@ -12,6 +12,7 @@ from typing_extensions import override
 
 from typing import Union
 
+from ...env_config import env_int
 from ...scribe import scribe
 from ..__init__ import (
     ErrorConfig,
@@ -538,11 +539,29 @@ class SessionContainer(Container):
 
 # Backstop TTL (seconds) after which a run_id mapping is considered abandoned
 # and swept. This is only a safety net for runs whose terminal callback
-# (on_*_end / on_*_error) never fires - e.g. a cancelled stream or a client
-# disconnect. It is refreshed on every access, so genuinely active (even very
-# long-running) traces are never evicted. Set generously to avoid dropping a
-# slow-but-live run. 2 hours.
-CONTAINER_MAPPING_TTL = 60 * 60 * 2
+# (on_*_end / on_*_error) never fires - e.g. a cancelled stream, a client
+# disconnect, or a process killed mid-run.
+#
+# The timestamp is refreshed on every access, and every child callback touches
+# its parent, so the window only has to outlast the gap between two consecutive
+# callbacks of the same run - never the run's total duration. A multi-step
+# agent that keeps emitting callbacks is never evicted no matter how long it
+# runs. The one thing this window must exceed is a single leaf call (one LLM
+# generation or tool execution) that emits no callbacks while in flight, so an
+# active-but-slow trace is not swept out from under its own terminal callback.
+#
+# One hour by default: comfortably longer than any realistic single LLM or tool
+# call. Now that terminal callbacks release their mappings, the only entries
+# that actually reach this TTL are genuinely abandoned runs, whose volume is
+# tiny, so a generous window costs almost nothing in memory. Deployments with
+# legitimately long-idle (e.g. human-in-the-loop) traces can raise it via
+# MAXIM_CONTAINER_MAPPING_TTL_SECONDS.
+CONTAINER_MAPPING_TTL_ENV = "MAXIM_CONTAINER_MAPPING_TTL_SECONDS"
+DEFAULT_CONTAINER_MAPPING_TTL = 60 * 60
+
+
+def _default_container_ttl() -> int:
+    return env_int(CONTAINER_MAPPING_TTL_ENV, DEFAULT_CONTAINER_MAPPING_TTL, minimum=1)
 
 
 class ContainerManager:
@@ -559,12 +578,17 @@ class ContainerManager:
     and expired entries are swept on writes.
     """
 
-    def __init__(self, ttl_seconds: int = CONTAINER_MAPPING_TTL) -> None:
+    def __init__(self, ttl_seconds: Optional[int] = None) -> None:
         # Map a run_id (as string) to (container, last_touched_epoch)
         self._run_id_to_container: dict[str, tuple[Container, float]] = {}
         # Track top-level root trace containers keyed by run_id -> (trace, last_touched_epoch)
         self._root_run_id_to_trace: dict[str, tuple[TraceContainer, float]] = {}
-        self._ttl_seconds = ttl_seconds
+        # Read the env default lazily (at construction, not import) so it can be
+        # set by an embedding app or a test before the manager is created. An
+        # explicit ttl_seconds always wins.
+        self._ttl_seconds = (
+            ttl_seconds if ttl_seconds is not None else _default_container_ttl()
+        )
 
     def _sweep_expired(self) -> None:
         """Remove mappings that have not been touched within the TTL window."""

--- a/maxim/logger/parsers/generation_parser.py
+++ b/maxim/logger/parsers/generation_parser.py
@@ -1,10 +1,5 @@
-import datetime
-import decimal
-import enum
 import json
-import pathlib
 import types
-import uuid
 from typing import Any, Dict, List, Optional
 
 # A bit of workaround to make sure there are no breakages when openai is not installed
@@ -16,6 +11,7 @@ except Exception:  # pragma: no cover
     Function = None  # type: ignore[assignment]
 
 from ...scribe import scribe
+from .json_safe import UNHANDLED, json_safe_scalar
 from .core import (
     validate_content,
     validate_optional_type,
@@ -222,50 +218,34 @@ def default_json_serializer(o: Any) -> Any:
     Returns:
         The serialized object.
     """
-    if isinstance(o, enum.Enum):
-        return o.value
-    # Read-only dict wrappers (e.g. a class' __dict__) are not JSON serializable
-    # by default.
-    if isinstance(o, types.MappingProxyType):
-        return dict(o)
+    # Scalar conversions are shared with CustomEncoder so that a type handled
+    # here cannot raise on the payload path (or vice versa).
+    converted = json_safe_scalar(o)
+    if converted is not UNHANDLED:
+        return converted
     # Classes must be handled before the instance-method branches below, since
     # those methods exist on the class as unbound functions and would raise if
     # called without an instance. A model *class* is how structured-output
-    # formats are usually declared (e.g. response_format=MyModel), and its
-    # schema is the meaningful representation.
+    # formats are usually declared (e.g. response_format=MyModel).
+    #
+    # We deliberately record only the class name, not its expanded JSON schema.
+    # A schema runs to hundreds of bytes on every generation, and nothing
+    # consumes it: it is stored in an opaque jsonb column, is never indexed,
+    # filtered or aggregated, and the UI renders model parameters via
+    # String(value) into a truncated cell. Expanding it here inflated payloads
+    # ~33x, which is enough to stall the log writer and, past the ingest
+    # 900KB-per-line limit, to get the whole log line dropped.
     if isinstance(o, type):
-        # pydantic v2 model class
-        if callable(getattr(o, "model_json_schema", None)):
-            return o.model_json_schema()
-        # pydantic v1 model class
-        if callable(getattr(o, "schema", None)):
-            return o.schema()
         return {"type": o.__name__}
-    if isinstance(o, (datetime.datetime, datetime.date, datetime.time)):
-        return o.isoformat()
-    if isinstance(o, datetime.timedelta):
-        return o.total_seconds()
-    if isinstance(o, decimal.Decimal):
-        return float(o)
-    if isinstance(o, uuid.UUID):
-        return str(o)
-    if isinstance(o, pathlib.PurePath):
-        return str(o)
-    if isinstance(o, (set, frozenset)):
-        return list(o)
-    if isinstance(o, (bytes, bytearray)):
-        return o.decode("utf-8", errors="replace")
+    # Explicit serialization contracts are honoured: an object that defines
+    # to_dict()/model_dump() is declaring how it wants to be represented, and
+    # the size cap in parse_model_parameters bounds the result.
     if callable(getattr(o, "to_dict", None)):
         return o.to_dict()
     # Pydantic v2 model instances expose model_dump().
     if callable(getattr(o, "model_dump", None)):
         return o.model_dump()
-    # numpy scalars and arrays (duck-typed, so numpy stays an optional import).
-    # tolist() covers both and returns native python types.
-    if callable(getattr(o, "tolist", None)):
-        return o.tolist()
-    # Functions and exceptions would otherwise fall through to vars() and
-    # serialize as a misleading empty dict, so describe them instead.
+    # Functions and exceptions are described rather than expanded.
     if isinstance(
         o, (types.FunctionType, types.BuiltinFunctionType, types.MethodType)
     ):
@@ -273,22 +253,17 @@ def default_json_serializer(o: Any) -> Any:
     if isinstance(o, BaseException):
         return {"type": type(o).__name__, "message": str(o)}
 
-    try:
-        return vars(o)
-    except TypeError:
-        pass
-
-    # Objects using __slots__ have no __dict__, so vars() above fails on them.
-    slots: List[str] = []
-    for klass in type(o).__mro__:
-        klass_slots = getattr(klass, "__slots__", ())
-        if isinstance(klass_slots, str):
-            klass_slots = (klass_slots,)
-        slots.extend(klass_slots)
-    if slots:
-        return {s: getattr(o, s) for s in slots if hasattr(o, s)}
-
-    raise TypeError(f"Object of type {o.__class__.__name__} is not JSON serializable")
+    # Anything else is described, not structurally expanded.
+    #
+    # We previously walked objects that declare no serialization contract:
+    # vars(o), a __slots__ fallback, and a duck-typed tolist() hook, with
+    # json.dumps recursing into whatever came back. That has no size bound. A
+    # parameter holding a client or a callback manager expands into a document
+    # orders of magnitude larger than the parameter itself, and tolist() turns
+    # a single embedding vector into tens of KB - on every generation. Model
+    # parameters are metadata about a call, so for an object that never said
+    # how to serialize itself, the type name is the part worth keeping.
+    return {"type": type(o).__name__}
 
 
 def is_openai_response_structure(data: Any) -> bool:
@@ -605,6 +580,66 @@ def parse_messages(messages: List[Any]) -> List[Any]:
     return [parse_message(message) for message in messages]
 
 
+# Backstop on the serialized size of a single model parameter. The serializer
+# falls back to vars(o), which json.dumps then walks recursively, so a parameter
+# holding an ordinary object (a bound client, a callback manager) can expand
+# into an arbitrarily large document. Set high enough that no real parameter
+# reaches it - this guards the runaway walk, it is not a general size policy.
+MAX_SERIALIZED_PARAM_BYTES = 64 * 1024
+
+
+def _dumps_capped(value: Any, max_bytes: int) -> Optional[str]:
+    """
+    Serialize a value, abandoning the attempt once it exceeds max_bytes.
+
+    Uses iterencode so an oversized object graph is abandoned partway through
+    rather than fully materialized and then measured. That bounds the peak
+    memory and CPU of the walk, not just the size of the retained result.
+
+    Returns None if the value does not fit.
+    """
+    encoder = json.JSONEncoder(default=default_json_serializer)
+    chunks: List[str] = []
+    total = 0
+    for chunk in encoder.iterencode(value):
+        total += len(chunk)
+        if total > max_bytes:
+            return None
+        chunks.append(chunk)
+    return "".join(chunks)
+
+
+def _collapse_duplicate_structured_output_schema(
+    parameters: Dict[str, Any],
+) -> Dict[str, Any]:
+    """
+    Drop the structured-output schema that LangChain reports twice.
+
+    For structured output LangChain populates both `response_format` and
+    `ls_structured_output_format.kwargs.schema` with the *same* object, so both
+    expand to the same value. We keep `response_format` and replace the
+    duplicate with a reference, retaining the surrounding `method` field.
+
+    Compares by identity, so a genuinely different schema in either slot is
+    left alone. Returns a shallow copy; the caller's dict is not mutated.
+    """
+    response_format = parameters.get("response_format")
+    ls_format = parameters.get("ls_structured_output_format")
+    if response_format is None or not isinstance(ls_format, dict):
+        return parameters
+    kwargs = ls_format.get("kwargs")
+    if not isinstance(kwargs, dict) or "schema" not in kwargs:
+        return parameters
+    if kwargs["schema"] is not response_format:
+        return parameters
+    collapsed = dict(parameters)
+    collapsed["ls_structured_output_format"] = {
+        **ls_format,
+        "kwargs": {**kwargs, "schema": "<same as response_format>"},
+    }
+    return collapsed
+
+
 def parse_model_parameters(parameters: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     """
     Parse model parameters from a dictionary.
@@ -618,6 +653,7 @@ def parse_model_parameters(parameters: Optional[Dict[str, Any]]) -> Dict[str, An
     # convert parameters dict into JSON string
     if parameters is None:
         return {}
+    parameters = _collapse_duplicate_structured_output_schema(parameters)
     new_parameters = {}
     # we will go through each key and make sure it is a string
     # if not we will do json.dumps on it
@@ -626,11 +662,25 @@ def parse_model_parameters(parameters: Optional[Dict[str, Any]]) -> Dict[str, An
             continue
         if not isinstance(value, str):
             try:
-                new_parameters[key] = json.dumps(value, default=default_json_serializer)
+                serialized = _dumps_capped(value, MAX_SERIALIZED_PARAM_BYTES)
             except Exception as e:
                 scribe().warning(
                     f'[MaximSDK] Failed to stringify model_parameters key - "{key}": {e}. Skipping it'
                 )
+                continue
+            if serialized is None:
+                # Record that the parameter was present rather than dropping it
+                # silently, but do not ship an unbounded payload for it.
+                scribe().warning(
+                    f'[MaximSDK] model_parameters key - "{key}" exceeds '
+                    f"{MAX_SERIALIZED_PARAM_BYTES} bytes serialized. "
+                    "Logging a placeholder instead."
+                )
+                serialized = json.dumps(
+                    f"<omitted: {type(value).__name__} exceeds "
+                    f"{MAX_SERIALIZED_PARAM_BYTES} bytes>"
+                )
+            new_parameters[key] = serialized
         else:
             new_parameters[key] = value
     return new_parameters

--- a/maxim/logger/parsers/json_safe.py
+++ b/maxim/logger/parsers/json_safe.py
@@ -1,0 +1,55 @@
+"""
+Shared conversions for values that json.dumps cannot encode natively.
+
+Two serializers in the SDK need these: ``default_json_serializer`` (model
+parameters) and ``CustomEncoder`` (the log payload that goes over the wire).
+They deliberately differ in how they treat *objects* - model parameters are
+metadata about a call and are recorded by type name, while payload content
+(messages, results) must be expanded - but the scalar conversions below have
+to be identical in both. Keeping them in one place is what stops a type from
+being handled on one path and raising on the other, which is how
+"Object of type mappingproxy is not JSON serializable" survived a fix that
+only touched the model-parameter path.
+"""
+
+import datetime
+import decimal
+import enum
+import pathlib
+import types
+import uuid
+from typing import Any
+
+# Returned when a value needs no scalar conversion, so callers can distinguish
+# "not handled here" from a legitimate None/falsy conversion result.
+UNHANDLED = object()
+
+
+def json_safe_scalar(o: Any) -> Any:
+    """
+    Convert a value with no native JSON representation into one that has.
+
+    Returns UNHANDLED if the value is not one of these types, leaving the
+    caller to apply its own policy for objects.
+    """
+    if isinstance(o, enum.Enum):
+        return o.value
+    # Read-only dict wrappers (e.g. a class' __dict__) are not JSON
+    # serializable by default.
+    if isinstance(o, types.MappingProxyType):
+        return dict(o)
+    if isinstance(o, (datetime.datetime, datetime.date, datetime.time)):
+        return o.isoformat()
+    if isinstance(o, datetime.timedelta):
+        return o.total_seconds()
+    if isinstance(o, decimal.Decimal):
+        return float(o)
+    if isinstance(o, uuid.UUID):
+        return str(o)
+    if isinstance(o, pathlib.PurePath):
+        return str(o)
+    if isinstance(o, (set, frozenset)):
+        return list(o)
+    if isinstance(o, (bytes, bytearray)):
+        return o.decode("utf-8", errors="replace")
+    return UNHANDLED

--- a/maxim/logger/writer.py
+++ b/maxim/logger/writer.py
@@ -22,6 +22,27 @@ from ..apis import MaximAPI
 from ..scribe import scribe
 from .components.types import CommitLog
 
+# Concurrent uploads of log batches. A single worker serialized every flush
+# behind one HTTP round trip, so any latency in the backend translated
+# directly into an unbounded in-memory backlog.
+FLUSH_WORKERS = 4
+
+# Batches allowed in the executor at once before further batches are spilled to
+# disk rather than queued in memory. This is what bounds memory when the
+# backend is slow or unreachable: logs are never dropped, they move to disk and
+# are replayed by flush_log_files.
+MAX_IN_FLIGHT_BATCHES = 5
+
+# Spilled files replayed per flush cycle. Replaying every file each cycle made
+# a large backlog re-read itself from scratch on every pass.
+MAX_REPLAY_FILES_PER_CYCLE = 20
+
+# Consecutive push failures after which a spilled file is quarantined rather
+# than retried forever. A file the server will never accept (malformed, or too
+# large for the endpoint) otherwise blocks every file behind it and is fully
+# re-read into memory on every cycle.
+MAX_FILE_REPLAY_ATTEMPTS = 5
+
 
 class LogWriterConfig:
     """
@@ -92,7 +113,7 @@ class LogWriter:
         self.maxim_api = MaximAPI(config.base_url, config.api_key)
         self.queue = Queue()
         self.upload_queue = Queue()
-        self.executor = ThreadPoolExecutor(max_workers=1)
+        self.executor = ThreadPoolExecutor(max_workers=FLUSH_WORKERS)
         self.upload_executor = ThreadPoolExecutor(max_workers=1)
         self.max_in_memory_logs = 100
         self.is_debug = config.is_debug
@@ -102,6 +123,18 @@ class LogWriter:
         )
         self.sinks: list[LogWriter] = []
         self.__flush_thread = None
+        # Number of batches handed to the executor and not yet finished. The
+        # executor's own queue is unbounded, so without this counter a backend
+        # that is slower than the log rate lets batches stack in memory until
+        # the process dies. Batches beyond the limit go to disk instead.
+        self.__in_flight = 0
+        self.__in_flight_lock = threading.Lock()
+        # flush_log_files may now run on several workers at once; without this
+        # two workers can read and push the same file, duplicating logs.
+        self.__file_replay_lock = threading.Lock()
+        # Consecutive push failures per spilled file, so that one file the
+        # server will never accept cannot block every file behind it forever.
+        self.__file_failures: dict[str, int] = {}
         try:
             os.makedirs(self.logs_dir, exist_ok=True)
         except Exception:
@@ -341,10 +374,16 @@ class LogWriter:
             Exception: If raise_exceptions is True and writing fails.
         """
         try:
-            filename = f"logs-{time.strftime('%Y-%m-%dT%H:%M:%SZ')}.log"
+            # The timestamp alone is only second-resolution and the file is
+            # opened truncating, so two spills within the same second used to
+            # overwrite each other - losing a whole batch precisely when the
+            # backend was struggling and spills were most frequent.
+            filename = (
+                f"logs-{time.strftime('%Y-%m-%dT%H:%M:%SZ')}-{uuid.uuid4().hex[:8]}.log"
+            )
             filepath = os.path.join(self.logs_dir, filename)
             scribe().info(f"[MaximSDK] Writing logs to file: {filename}")
-            with open(filepath, "w") as file:
+            with open(filepath, "x") as file:
                 for log in logs:
                     file.write(log.serialize() + "\n")
             return filepath
@@ -356,6 +395,39 @@ class LogWriter:
                 raise e
             return None
 
+    def __record_replay_failure(self, file: str, filepath: str, error: Exception) -> bool:
+        """
+        Count one failed replay attempt for ``file`` and quarantine it once it
+        has exhausted MAX_FILE_REPLAY_ATTEMPTS.
+
+        Returns:
+            bool: True when the file was quarantined (renamed to ``.failed``),
+                so the caller should move on to the next file.
+        """
+        attempts = self.__file_failures.get(file, 0) + 1
+        self.__file_failures[file] = attempts
+        if attempts < MAX_FILE_REPLAY_ATTEMPTS:
+            return False
+        # Park it under a name this loop no longer picks up. The data stays
+        # on disk for inspection rather than being deleted, but it stops
+        # blocking every file behind it and stops being re-read every cycle.
+        self.__file_failures.pop(file, None)
+        try:
+            os.rename(filepath, filepath + ".failed")
+            scribe().error(
+                "[MaximSDK] Giving up on spilled log file %s after "
+                "%s attempts; kept as %s.failed. Last error: %s",
+                file,
+                attempts,
+                file,
+                error,
+            )
+        except Exception:
+            scribe().error(
+                f"[MaximSDK] Failed to quarantine log file {file}: {error}"
+            )
+        return True
+
     def flush_log_files(self):
         """
         Flush logs from files to the Maxim API.
@@ -366,24 +438,71 @@ class LogWriter:
         Raises:
             Exception: If raise_exceptions is True and an error occurs.
         """
+        # Several flush workers can reach this concurrently; without the lock
+        # two of them read and push the same file, duplicating those logs.
+        if not self.__file_replay_lock.acquire(blocking=False):
+            return
         try:
-            if not os.path.exists(self.logs_dir):
+            # Only the directory listing is guarded here: every failure inside
+            # the replay loop below is handled per-file, and a deliberate
+            # raise_exceptions re-raise must propagate rather than being
+            # swallowed as a filesystem warning.
+            try:
+                if not os.path.exists(self.logs_dir):
+                    return
+                files = sorted(
+                    f for f in os.listdir(self.logs_dir) if f.endswith(".log")
+                )
+            except Exception as e:
+                scribe().warning(
+                    f"[MaximSDK] Failed to access filesystem. Error: {e}"
+                )
                 return
-            files = os.listdir(self.logs_dir)
+            if len(files) > MAX_REPLAY_FILES_PER_CYCLE:
+                scribe().warning(
+                    "[MaximSDK] %s spilled log files pending; replaying %s this "
+                    "cycle, the rest follow on later cycles.",
+                    len(files),
+                    MAX_REPLAY_FILES_PER_CYCLE,
+                )
+                files = files[:MAX_REPLAY_FILES_PER_CYCLE]
             for file in files:
-                with open(os.path.join(self.logs_dir, file), "r") as f:
-                    logs = f.read()
+                filepath = os.path.join(self.logs_dir, file)
                 try:
-                    self.maxim_api.push_logs(self.config.repository_id, logs)
-                    os.remove(os.path.join(self.logs_dir, file))
+                    with open(filepath, "r") as f:
+                        logs = f.read()
                 except Exception as e:
                     scribe().warning(
-                        f"[MaximSDK] Failed to access filesystem. Error: {e}"
+                        f"[MaximSDK] Failed to read spilled log file {file}. Error: {e}"
+                    )
+                    # An unreadable file counts against the same attempt budget
+                    # as an unpushable one; otherwise it is retried forever and
+                    # occupies one of the MAX_REPLAY_FILES_PER_CYCLE slots on
+                    # every cycle.
+                    self.__record_replay_failure(file, filepath, e)
+                    continue
+                try:
+                    self.maxim_api.push_logs(self.config.repository_id, logs)
+                    os.remove(filepath)
+                    self.__file_failures.pop(file, None)
+                except Exception as e:
+                    if self.__record_replay_failure(file, filepath, e):
+                        continue
+                    scribe().warning(
+                        "[MaximSDK] Failed to push spilled log file %s "
+                        "(attempt %s/%s). Error: %s",
+                        file,
+                        self.__file_failures[file],
+                        MAX_FILE_REPLAY_ATTEMPTS,
+                        e,
                     )
                     if self.raise_exceptions:
-                        raise Exception(e)
-        except Exception as e:
-            scribe().warning(f"[MaximSDK] Failed to access filesystem. Error: {e}")
+                        raise Exception(e) from e
+                    # Stop this cycle: the backend is unhappy, and hammering it
+                    # with the remaining files achieves nothing.
+                    break
+        finally:
+            self.__file_replay_lock.release()
 
     def can_access_filesystem(self):
         """
@@ -593,6 +712,35 @@ class LogWriter:
                 self.upload_attachments(items)
         scribe().debug(f"[MaximSDK] Flushed {len(items)} attachments")
 
+    def __should_spill_instead_of_submitting(self) -> bool:
+        """
+        True when the executor already holds its limit of unfinished batches.
+        """
+        with self.__in_flight_lock:
+            return self.__in_flight >= MAX_IN_FLIGHT_BATCHES
+
+    def __submit_flush(self, items: "list[CommitLog]") -> None:
+        """
+        Hand a batch to the executor, tracking it so the backlog stays bounded.
+        """
+        with self.__in_flight_lock:
+            self.__in_flight += 1
+
+        def run():
+            try:
+                self.flush_logs(items)
+            finally:
+                with self.__in_flight_lock:
+                    self.__in_flight -= 1
+
+        try:
+            self.executor.submit(run)
+        except Exception:
+            # submit() failed, so run() will never decrement the counter.
+            with self.__in_flight_lock:
+                self.__in_flight -= 1
+            raise
+
     def flush_commit_logs(self, is_sync=False):
         """
         Flush all queued commit logs to the Maxim API.
@@ -610,14 +758,32 @@ class LogWriter:
         scribe().debug(
             f"[MaximSDK] Flushing logs to server {time.strftime('%Y-%m-%dT%H:%M:%S')} with {len(items)} items"
         )
-        for item in items:
-            scribe().debug(f"[MaximSDK] {item.serialize()[:1000]}")
+        if self.is_debug:
+            # serialize() is not free, and the f-string built its result for
+            # every log on every flush even with debug logging switched off.
+            for item in items:
+                scribe().debug(f"[MaximSDK] {item.serialize()[:1000]}")
         # if we are running on lambda - we will flush without submitting to the executor
         if self.is_running_on_lambda() or is_sync:
             self.flush_logs(items)
+        elif self.__should_spill_instead_of_submitting():
+            # The executor is saturated. Its internal queue is unbounded, so
+            # submitting anyway is how a slow backend turns into an OOM. Spill
+            # to disk instead: nothing is dropped, and flush_log_files replays
+            # these once the backend keeps up again.
+            scribe().warning(
+                "[MaximSDK] %s log batches already in flight; writing this batch "
+                "to disk to bound memory. It will be retried on a later flush.",
+                MAX_IN_FLIGHT_BATCHES,
+            )
+            if self.write_to_file(items) is None:
+                # No filesystem to spill to. Submitting is worse than blocking
+                # here, so push synchronously and let backpressure reach the
+                # caller rather than growing the backlog without limit.
+                self.flush_logs(items)
         else:
             try:
-                self.executor.submit(self.flush_logs, items)
+                self.__submit_flush(items)
             except Exception as e:
                 scribe().warning(
                     f"[MaximSDK] Error while flushing logs from worker. Error: {e}.\nFlushing synchronously"

--- a/maxim/tests/test_commit_log_serializer.py
+++ b/maxim/tests/test_commit_log_serializer.py
@@ -1,0 +1,182 @@
+"""
+Tests for CustomEncoder, the serializer every log payload passes through.
+
+The original "Object of type mappingproxy is not JSON serializable" report was
+fixed only in default_json_serializer, which handles model parameters. The
+payload path used this encoder instead, so the error survived the fix. These
+tests pin the two properties that keep the paths from diverging again:
+the scalar conversions match, and payload content is still expanded.
+"""
+
+import datetime
+import decimal
+import enum
+import json
+import pathlib
+import types
+import unittest
+import uuid
+from collections import namedtuple
+
+from pydantic import BaseModel
+
+from maxim.logger.components.types import CommitLog, CustomEncoder, Entity
+from maxim.logger.parsers.generation_parser import default_json_serializer
+
+
+class Weather(BaseModel):
+    temp: float
+    city: str
+
+
+class Colour(enum.Enum):
+    RED = "red"
+
+
+def encode(value):
+    return json.loads(json.dumps({"v": value}, cls=CustomEncoder))["v"]
+
+
+class TestScalarConversions(unittest.TestCase):
+    """Types with no native JSON form must encode, not raise."""
+
+    def test_mapping_proxy(self):
+        self.assertEqual(encode(types.MappingProxyType({"a": 1})), {"a": 1})
+
+    def test_class_object_does_not_manufacture_a_mappingproxy(self):
+        # vars() of a class returns a mappingproxy, which used to re-enter
+        # default() and raise. This was the actual reported failure.
+        self.assertEqual(encode(Weather), {"type": "Weather"})
+
+    def test_pydantic_model_class_does_not_call_unbound_method(self):
+        # hasattr(cls, "model_dump") is True, but calling it without an
+        # instance raises TypeError: missing 'self'.
+        self.assertEqual(encode(Weather), {"type": "Weather"})
+
+    def test_enum(self):
+        self.assertEqual(encode(Colour.RED), "red")
+
+    def test_datetime_and_date(self):
+        self.assertEqual(encode(datetime.datetime(2026, 7, 21, 9, 0)), "2026-07-21T09:00:00")
+        self.assertEqual(encode(datetime.date(2026, 7, 21)), "2026-07-21")
+
+    def test_timedelta(self):
+        self.assertEqual(encode(datetime.timedelta(seconds=90)), 90.0)
+
+    def test_decimal(self):
+        self.assertEqual(encode(decimal.Decimal("2.5")), 2.5)
+
+    def test_uuid(self):
+        self.assertEqual(encode(uuid.UUID(int=7)), "00000000-0000-0000-0000-000000000007")
+
+    def test_path(self):
+        self.assertEqual(encode(pathlib.PurePosixPath("/a/b")), "/a/b")
+
+    def test_set(self):
+        self.assertEqual(sorted(encode({1, 2})), [1, 2])
+
+    def test_bytes(self):
+        self.assertEqual(encode(b"hi"), "hi")
+
+    def test_invalid_utf8_bytes_are_replaced_not_raised(self):
+        self.assertIsInstance(encode(b"\xff\xfe"), str)
+
+
+class TestScalarParityWithModelParameterPath(unittest.TestCase):
+    """
+    The two serializers may differ on objects, but not on scalars.
+
+    Divergence here is exactly how the mappingproxy bug survived its fix.
+    """
+
+    def test_scalar_types_agree_across_both_serializers(self):
+        for value in [
+            types.MappingProxyType({"a": 1}),
+            Colour.RED,
+            datetime.datetime(2026, 7, 21, 9, 0),
+            datetime.date(2026, 7, 21),
+            datetime.timedelta(seconds=90),
+            decimal.Decimal("2.5"),
+            uuid.UUID(int=7),
+            pathlib.PurePosixPath("/a/b"),
+            frozenset([1]),
+            b"hi",
+        ]:
+            with self.subTest(value=type(value).__name__):
+                self.assertEqual(
+                    json.dumps(encode(value), sort_keys=True),
+                    json.dumps(default_json_serializer(value), sort_keys=True),
+                )
+
+
+class TestPayloadContentIsStillExpanded(unittest.TestCase):
+    """
+    CustomEncoder must NOT adopt the descriptor policy used for model
+    parameters. It serializes messages and results, where the object is the
+    content: collapsing it to a type name would empty the log.
+    """
+
+    def test_plain_object_is_expanded(self):
+        class AIMessage:
+            def __init__(self):
+                self.role = "assistant"
+                self.content = "Paris"
+
+        self.assertEqual(encode(AIMessage()), {"role": "assistant", "content": "Paris"})
+
+    def test_pydantic_instance_is_expanded(self):
+        self.assertEqual(encode(Weather(temp=1.0, city="x")), {"temp": 1.0, "city": "x"})
+
+    def test_namedtuple_is_encoded(self):
+        Point = namedtuple("Point", ["x", "y"])
+        # json encodes tuples as arrays before default() is ever consulted.
+        self.assertEqual(encode(Point(1, 2)), [1, 2])
+
+    def test_object_with_to_dict_is_expanded(self):
+        class HasToDict:
+            def to_dict(self):
+                return {"kind": "to_dict"}
+
+        self.assertEqual(encode(HasToDict()), {"kind": "to_dict"})
+
+
+class TestCommitLogSerialize(unittest.TestCase):
+    def test_mappingproxy_no_longer_drops_the_whole_key(self):
+        # Previously CustomEncoder raised, serialize() bisected the payload and
+        # deleted the entire modelParameters block - silent data loss that read
+        # as "the mappingproxy fix didn't work".
+        log = CommitLog(
+            Entity.GENERATION,
+            "g1",
+            "create",
+            {
+                "model": "gpt-4o",
+                "modelParameters": {"response_format": types.MappingProxyType({"a": 1})},
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+        wire = log.serialize()
+        self.assertIn("modelParameters", wire)
+        self.assertIn("messages", wire)
+
+    def test_class_valued_parameter_no_longer_drops_the_whole_key(self):
+        log = CommitLog(
+            Entity.GENERATION,
+            "g2",
+            "create",
+            {"modelParameters": {"response_format": Weather}, "model": "gpt-4o"},
+        )
+        self.assertIn("modelParameters", log.serialize())
+
+    def test_serialize_still_survives_a_truly_unserializable_value(self):
+        class Exploding:
+            def to_dict(self):
+                raise RuntimeError("boom")
+
+        log = CommitLog(Entity.GENERATION, "g3", "create", {"bad": Exploding(), "model": "gpt-4o"})
+        wire = log.serialize()
+        self.assertIn("gpt-4o", wire)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/maxim/tests/test_generation_parser_serializer.py
+++ b/maxim/tests/test_generation_parser_serializer.py
@@ -61,12 +61,13 @@ class TestDefaultJsonSerializer(unittest.TestCase):
             default_json_serializer(HasModelDump()), {"kind": "model_dump"}
         )
 
-    def test_pydantic_model_class_returns_json_schema(self):
+    def test_pydantic_model_class_returns_compact_descriptor(self):
         # A model *class* must not hit the model_dump() branch, which would
-        # call an unbound method and raise.
+        # call an unbound method and raise. It must also not expand into its
+        # full JSON schema: that is hundreds of bytes on every generation and
+        # no consumer reads it, so we record only the class name.
         result = default_json_serializer(Weather)
-        self.assertIsInstance(result, dict)
-        self.assertEqual(sorted(result["properties"].keys()), ["city", "temp"])
+        self.assertEqual(result, {"type": "Weather"})
 
     def test_pydantic_model_instance_still_uses_model_dump(self):
         self.assertEqual(
@@ -107,15 +108,17 @@ class TestDefaultJsonSerializer(unittest.TestCase):
         self.assertIsInstance(result, str)
         self.assertEqual(result, "�")
 
-    def test_plain_object_falls_back_to_vars(self):
+    def test_plain_object_is_described_not_expanded(self):
+        # An object that declares no serialization contract is recorded by
+        # type name. Walking vars(o) had no size bound: a parameter holding a
+        # client or callback manager expanded into a document far larger than
+        # the parameter itself, on every generation.
         self.assertEqual(
-            default_json_serializer(PlainObject()), {"a": 1, "b": "two"}
+            default_json_serializer(PlainObject()), {"type": "PlainObject"}
         )
 
-    def test_unserializable_object_raises_type_error(self):
-        with self.assertRaises(TypeError):
-            # a raw class' __dict__ contains C-level descriptors
-            default_json_serializer(object())
+    def test_unknown_object_is_described_not_raised(self):
+        self.assertEqual(default_json_serializer(object()), {"type": "object"})
 
 
 class TestStdlibScalarTypes(unittest.TestCase):
@@ -154,7 +157,7 @@ class TestStdlibScalarTypes(unittest.TestCase):
 class TestObjectShapes(unittest.TestCase):
     """Objects whose natural fallback would be lossy or wrong."""
 
-    def test_slotted_object_uses_slots(self):
+    def test_slotted_object_is_described_not_expanded(self):
         class Slotted:
             __slots__ = ("a", "b")
 
@@ -162,17 +165,7 @@ class TestObjectShapes(unittest.TestCase):
                 self.a = 1
                 self.b = 2
 
-        # vars() raises on __slots__ objects; must fall back to slot names.
-        self.assertEqual(default_json_serializer(Slotted()), {"a": 1, "b": 2})
-
-    def test_string_slots_are_handled(self):
-        class OneSlot:
-            __slots__ = "a"  # a bare string, not a tuple
-
-            def __init__(self):
-                self.a = 1
-
-        self.assertEqual(default_json_serializer(OneSlot()), {"a": 1})
+        self.assertEqual(default_json_serializer(Slotted()), {"type": "Slotted"})
 
     def test_function_is_named_not_empty_dict(self):
         def a_tool(city: str) -> str:
@@ -187,20 +180,15 @@ class TestObjectShapes(unittest.TestCase):
             {"type": "ValueError", "message": "bad"},
         )
 
-    def test_numpy_like_scalar_uses_tolist(self):
-        # duck-typed so numpy stays an optional dependency
-        class FakeScalar:
-            def tolist(self):
-                return 5
-
-        self.assertEqual(default_json_serializer(FakeScalar()), 5)
-
-    def test_numpy_like_array_uses_tolist(self):
+    def test_numpy_like_array_is_described_not_expanded(self):
+        # tolist() was the most expensive expansion in practice: a single
+        # embedding vector is ~1536 floats, tens of KB of JSON, on every
+        # generation. An array is not metadata about the call.
         class FakeArray:
             def tolist(self):
                 return [1, 2, 3]
 
-        self.assertEqual(default_json_serializer(FakeArray()), [1, 2, 3])
+        self.assertEqual(default_json_serializer(FakeArray()), {"type": "FakeArray"})
 
 
 class TestNotConsumedOrGuessed(unittest.TestCase):
@@ -213,13 +201,15 @@ class TestNotConsumedOrGuessed(unittest.TestCase):
         parse_model_parameters({"g": gen})
         self.assertEqual(list(gen), [0, 1, 2])
 
-    def test_circular_reference_is_skipped_not_raised(self):
+    def test_circular_reference_is_described_not_raised(self):
+        # The cycle is unreachable now that objects are not walked, but the
+        # shape must still not raise.
         class Circular:
             def __init__(self):
                 self.self_ref = self
 
         out = parse_model_parameters({"c": Circular(), "model": "gpt-4"})
-        self.assertNotIn("c", out)
+        self.assertEqual(json.loads(out["c"]), {"type": "Circular"})
         self.assertEqual(out["model"], "gpt-4")
 
     def test_raising_to_dict_is_skipped_not_raised(self):
@@ -268,12 +258,73 @@ class TestParseModelParameters(unittest.TestCase):
         # Regression: response_format=MyModel is the usual way structured output
         # is declared. vars() on the class yields a mappingproxy, which produced
         # the original "Object of type mappingproxy is not JSON serializable".
+        # It must serialize without raising, but compactly - see
+        # test_pydantic_model_class_response_format_stays_small.
         out = parse_model_parameters({"response_format": Weather, "model": "gpt-4"})
         self.assertIn("response_format", out)
-        self.assertEqual(
-            sorted(json.loads(out["response_format"])["properties"].keys()),
-            ["city", "temp"],
+        self.assertEqual(json.loads(out["response_format"]), {"type": "Weather"})
+
+    def test_pydantic_model_class_response_format_stays_small(self):
+        # Guards the 3.14.19 regression: expanding response_format into a full
+        # JSON schema inflated model parameters ~33x on every generation, which
+        # stalled the log writer and risked tripping the ingest per-line limit.
+        out = parse_model_parameters({"response_format": Weather, "model": "gpt-4"})
+        self.assertLess(len(out["response_format"]), 100)
+
+    def test_duplicate_structured_output_schema_is_collapsed(self):
+        # LangChain reports the same structured-output class in two places.
+        # Only one copy should be expanded.
+        out = parse_model_parameters(
+            {
+                "response_format": Weather,
+                "ls_structured_output_format": {
+                    "kwargs": {"method": "json_schema", "schema": Weather}
+                },
+            }
         )
+        ls_format = json.loads(out["ls_structured_output_format"])
+        self.assertEqual(ls_format["kwargs"]["method"], "json_schema")
+        self.assertEqual(ls_format["kwargs"]["schema"], "<same as response_format>")
+
+    def test_distinct_structured_output_schema_is_left_alone(self):
+        # A genuinely different schema in the second slot must survive.
+        class Other(BaseModel):
+            other: str
+
+        out = parse_model_parameters(
+            {
+                "response_format": Weather,
+                "ls_structured_output_format": {
+                    "kwargs": {"method": "json_schema", "schema": Other}
+                },
+            }
+        )
+        ls_format = json.loads(out["ls_structured_output_format"])
+        self.assertEqual(ls_format["kwargs"]["schema"], {"type": "Other"})
+
+    def test_oversized_parameter_is_replaced_with_placeholder(self):
+        # Objects are no longer walked, but native containers and explicit
+        # to_dict()/model_dump() results are still expanded and have no size
+        # bound of their own, so the cap remains the backstop.
+        class Big:
+            def to_dict(self):
+                return {f"k{i}": "x" * 500 for i in range(500)}
+
+        out = parse_model_parameters({"bound": Big(), "model": "gpt-4"})
+        self.assertEqual(out["model"], "gpt-4")
+        self.assertIn("bound", out)
+        self.assertLess(len(out["bound"]), 200)
+        self.assertIn("omitted", out["bound"])
+
+    def test_oversized_native_container_is_replaced_with_placeholder(self):
+        out = parse_model_parameters({"blob": {f"k{i}": "x" * 500 for i in range(500)}})
+        self.assertIn("omitted", out["blob"])
+
+    def test_parameter_just_under_cap_is_kept_whole(self):
+        # The cap must not disturb values that legitimately fit.
+        value = {"data": "x" * 1000}
+        out = parse_model_parameters({"payload": value})
+        self.assertEqual(json.loads(out["payload"]), value)
 
     def test_nested_values_are_serialized(self):
         # Nested is the common real shape; the serializer is applied recursively.
@@ -300,10 +351,11 @@ class TestParseModelParameters(unittest.TestCase):
         out = parse_model_parameters({"blob": b"hello"})
         self.assertEqual(json.loads(out["blob"]), "hello")
 
-    def test_unserializable_value_is_skipped_not_raised(self):
-        # Value that cannot be represented is skipped, other keys survive.
+    def test_unrepresentable_value_is_described_not_skipped(self):
+        # Recording the type is strictly better than dropping the key: the
+        # caller can see the parameter was set without us shipping its guts.
         out = parse_model_parameters({"bad": object(), "model": "gpt-4"})
-        self.assertNotIn("bad", out)
+        self.assertEqual(json.loads(out["bad"]), {"type": "object"})
         self.assertEqual(out["model"], "gpt-4")
 
 

--- a/maxim/tests/test_langchain_tracer_lifecycle.py
+++ b/maxim/tests/test_langchain_tracer_lifecycle.py
@@ -1,0 +1,403 @@
+"""
+Container lifecycle tests for the LangChain tracer.
+
+The tracer is a long-lived callback handler reused across every request, so
+anything it registers and fails to release accumulates for the process
+lifetime. These tests assert that each terminal callback releases what its
+start callback registered.
+
+The regression they exist for: cleanup used to be gated on
+`container.parent() is None` rather than `parent_run_id is None`. Those agree
+only when no session_id is set, so the leak was invisible to tests that did not
+pass one - which was all of them.
+"""
+
+import os
+import time
+import unittest
+import uuid
+from unittest.mock import MagicMock
+
+from langchain_core.messages import AIMessage
+from langchain_core.outputs import ChatGeneration, LLMResult
+
+from maxim.logger.langchain.tracer import MaximLangchainTracer
+
+
+class FakeGeneration:
+    """Stands in for a Generation; echoes the id it was configured with."""
+
+    def __init__(self, config):
+        self.id = config["id"]
+        self._name = "gen"
+
+    def result(self, *args, **kwargs):
+        pass
+
+    def add_attachment(self, *args, **kwargs):
+        pass
+
+
+def make_tracer():
+    logger = MagicMock()
+    logger.trace.return_value.add_generation.side_effect = lambda cfg: FakeGeneration(cfg)
+    return MaximLangchainTracer(logger)
+
+
+def llm_result():
+    return LLMResult(
+        generations=[[ChatGeneration(message=AIMessage(content="hi"))]],
+        llm_output={
+            "token_usage": {
+                "prompt_tokens": 1,
+                "completion_tokens": 1,
+                "total_tokens": 2,
+            }
+        },
+    )
+
+
+class LifecycleAssertions(unittest.TestCase):
+    def assertNoneRetained(self, tracer):
+        manager = tracer.container_manager
+        self.assertEqual(
+            (
+                len(manager._run_id_to_container),
+                len(manager._root_run_id_to_trace),
+                len(tracer.generation_container_store.store),
+                len(tracer.to_be_evaluated_container_store.store),
+            ),
+            (0, 0, 0, 0),
+            "tracer retained state after the run finished",
+        )
+
+
+class TestTopLevelLLMRun(LifecycleAssertions):
+    def _run(self, metadata):
+        tracer = make_tracer()
+        run_id = uuid.uuid4()
+        tracer.on_chat_model_start(
+            {"name": "ChatOpenAI"},
+            [[]],
+            run_id=run_id,
+            parent_run_id=None,
+            metadata=metadata,
+            invocation_params={"model": "gpt-4o"},
+        )
+        tracer.on_llm_end(llm_result(), run_id=run_id, parent_run_id=None)
+        return tracer
+
+    def test_run_without_session_id_is_released(self):
+        self.assertNoneRetained(self._run({}))
+
+    def test_run_with_session_id_is_released(self):
+        # The regression. A trace created with a session_id has a non-None
+        # parent, so the old `container.parent() is None` gate never fired and
+        # every such run leaked two mappings plus an unended trace.
+        self.assertNoneRetained(self._run({"maxim": {"session_id": "sess-123"}}))
+
+    def test_run_with_session_id_still_ends_its_trace(self):
+        # Releasing the mapping is not enough - the trace must also be closed,
+        # or the backend accumulates permanently open traces.
+        events = []
+        logger = MagicMock()
+        logger.trace.return_value.add_generation.side_effect = lambda c: FakeGeneration(c)
+        tracer = MaximLangchainTracer(logger, callback=lambda e, d: events.append(e))
+        run_id = uuid.uuid4()
+        tracer.on_chat_model_start(
+            {"name": "ChatOpenAI"},
+            [[]],
+            run_id=run_id,
+            parent_run_id=None,
+            metadata={"maxim": {"session_id": "sess-123"}},
+            invocation_params={"model": "gpt-4o"},
+        )
+        tracer.on_llm_end(llm_result(), run_id=run_id, parent_run_id=None)
+        self.assertIn("trace.ended", events)
+
+
+class TestLLMErrorPath(LifecycleAssertions):
+    def test_llm_error_releases_everything(self):
+        tracer = make_tracer()
+        run_id = uuid.uuid4()
+        tracer.on_chat_model_start(
+            {"name": "ChatOpenAI"},
+            [[]],
+            run_id=run_id,
+            parent_run_id=None,
+            metadata={},
+            invocation_params={"model": "gpt-4o"},
+        )
+        tracer.on_llm_error(RuntimeError("boom"), run_id=run_id, parent_run_id=None)
+        self.assertNoneRetained(tracer)
+
+    def test_llm_error_releases_pending_evaluator(self):
+        # The evaluator store holds a live Generation plus the input text and
+        # was never cleaned on the error path.
+        tracer = make_tracer()
+        run_id = uuid.uuid4()
+        tracer.on_chat_model_start(
+            {"name": "ChatOpenAI"},
+            [[]],
+            run_id=run_id,
+            parent_run_id=None,
+            metadata={},
+            invocation_params={"model": "gpt-4o"},
+        )
+        tracer.to_be_evaluated_container_store.set(
+            str(run_id),
+            {"generation_container": object(), "evaluators": [], "input": "x"},
+            60,
+        )
+        tracer.on_llm_error(RuntimeError("boom"), run_id=run_id, parent_run_id=None)
+        self.assertNoneRetained(tracer)
+
+    def test_stores_are_released_when_no_container_is_found(self):
+        # on_llm_end returns early when the container is missing; that path
+        # used to skip both store deletes.
+        tracer = make_tracer()
+        run_id = uuid.uuid4()
+        tracer.generation_container_store.set(str(run_id), object(), 60)
+        tracer.to_be_evaluated_container_store.set(str(run_id), {"x": 1}, 60)
+        tracer.container_manager.get_container = lambda _: None
+        tracer._MaximLangchainTracer__get_container = lambda *a, **k: None
+        tracer.on_llm_end(llm_result(), run_id=run_id, parent_run_id=None)
+        self.assertEqual(len(tracer.generation_container_store.store), 0)
+        self.assertEqual(len(tracer.to_be_evaluated_container_store.store), 0)
+
+
+class TestRetriever(LifecycleAssertions):
+    def test_retriever_success_releases_root_trace(self):
+        # on_retriever_end removed the run_id mapping but never popped the root
+        # trace, leaking one entry per retriever-rooted run.
+        tracer = make_tracer()
+        run_id = uuid.uuid4()
+        tracer.on_retriever_start(
+            {"name": "VectorStoreRetriever"}, "q", run_id=run_id, parent_run_id=None
+        )
+        tracer.on_retriever_end([], run_id=run_id, parent_run_id=None)
+        self.assertNoneRetained(tracer)
+
+    def test_retriever_error_releases_everything(self):
+        # There was no on_retriever_error at all, so a vector store timeout -
+        # a routine production event - had no terminal path.
+        tracer = make_tracer()
+        run_id = uuid.uuid4()
+        tracer.on_retriever_start(
+            {"name": "VectorStoreRetriever"}, "q", run_id=run_id, parent_run_id=None
+        )
+        tracer.on_retriever_error(
+            RuntimeError("vector store timeout"), run_id=run_id, parent_run_id=None
+        )
+        self.assertNoneRetained(tracer)
+
+    def test_on_retriever_error_is_implemented_not_inherited(self):
+        # BaseCallbackHandler provides a no-op, so hasattr() is not evidence.
+        self.assertIn("on_retriever_error", vars(MaximLangchainTracer))
+
+
+class TestToolCalls(LifecycleAssertions):
+    def _start(self, tracer, run_id):
+        tracer.on_tool_start(
+            {"name": "search", "description": "d"},
+            "query",
+            run_id=run_id,
+            parent_run_id=None,
+        )
+
+    def test_tool_end_releases(self):
+        tracer = make_tracer()
+        run_id = uuid.uuid4()
+        self._start(tracer, run_id)
+        tracer.on_tool_end({"status": "success", "content": "ok"}, run_id=run_id, parent_run_id=None)
+        self.assertNoneRetained(tracer)
+
+    def test_tool_error_releases(self):
+        # on_tool_error had no local parent_run_id binding at all.
+        tracer = make_tracer()
+        run_id = uuid.uuid4()
+        self._start(tracer, run_id)
+        tracer.on_tool_error(RuntimeError("boom"), run_id=run_id, parent_run_id=None)
+        self.assertNoneRetained(tracer)
+
+    def test_top_level_tool_with_trace_id_metadata_ends_the_trace(self):
+        # on_tool_start used to register the container mapping but not the root
+        # trace, so a trace_id-metadata container (built by
+        # __get_container_from_metadata, which does not self-register) was never
+        # popped at tool-end: no trace.end(), no trace.ended callback.
+        logger = MagicMock()
+        events = []
+        tracer = MaximLangchainTracer(
+            logger,
+            metadata={"trace_id": "external-trace"},
+            callback=lambda event, data: events.append(event),
+        )
+        run_id = uuid.uuid4()
+        self._start(tracer, run_id)
+        tracer.on_tool_end(
+            {"status": "success", "content": "ok"}, run_id=run_id, parent_run_id=None
+        )
+        self.assertNoneRetained(tracer)
+        self.assertIn("trace.ended", events)
+
+
+class TestChildRunsDoNotReleaseTheirParent(LifecycleAssertions):
+    def test_child_llm_leaves_the_parent_mapping_intact(self):
+        # A child must never release the container it borrowed from its parent;
+        # the parent run is still in flight.
+        tracer = make_tracer()
+        parent_run_id = uuid.uuid4()
+        child_run_id = uuid.uuid4()
+        tracer.on_chain_start(
+            {"name": "chain"}, {"input": "hi"}, run_id=parent_run_id, parent_run_id=None
+        )
+        before = len(tracer.container_manager._run_id_to_container)
+        tracer.on_chat_model_start(
+            {"name": "ChatOpenAI"},
+            [[]],
+            run_id=child_run_id,
+            parent_run_id=parent_run_id,
+            metadata={},
+            invocation_params={"model": "gpt-4o"},
+        )
+        tracer.on_llm_end(llm_result(), run_id=child_run_id, parent_run_id=parent_run_id)
+        self.assertEqual(
+            len(tracer.container_manager._run_id_to_container),
+            before,
+            "child run released a mapping it did not own",
+        )
+        tracer.on_chain_end({"output": "bye"}, run_id=parent_run_id, parent_run_id=None)
+        self.assertNoneRetained(tracer)
+
+
+class TestTTLBackstop(unittest.TestCase):
+    def test_default_ttl_exceeds_a_long_single_call(self):
+        # The window must outlast the longest single leaf call (one LLM or tool
+        # execution emits no callbacks while in flight), or an active-but-slow
+        # trace could be swept out from under its own terminal callback.
+        from maxim.logger.models.container import DEFAULT_CONTAINER_MAPPING_TTL
+
+        self.assertGreaterEqual(DEFAULT_CONTAINER_MAPPING_TTL, 60 * 30)
+
+    def test_abandoned_mapping_is_swept(self):
+        from maxim.logger.models.container import ContainerManager
+
+        manager = ContainerManager(ttl_seconds=0)
+        manager.set_container("abandoned", MagicMock())
+        manager.set_container("fresh", MagicMock())
+        # The sweep runs on write; the abandoned entry is past its TTL.
+        self.assertNotIn("abandoned", manager._run_id_to_container)
+
+    def test_active_run_is_not_swept_while_being_accessed(self):
+        # Refresh-on-access: a run that keeps being looked up survives even a
+        # TTL far shorter than its lifetime, but is swept once accesses stop.
+        # A fake clock lets us cross the TTL deterministically.
+        import maxim.logger.models.container as container_mod
+        from maxim.logger.models.container import ContainerManager
+
+        class Clock:
+            def __init__(self):
+                self.now = 1000.0
+
+            def time(self):
+                return self.now
+
+        clock = Clock()
+        saved = container_mod.time
+        container_mod.time = clock
+        try:
+            manager = ContainerManager(ttl_seconds=10)
+            container = MagicMock()
+            manager.set_container("active", container)
+            # Keep accessing "active" across intervals shorter than the TTL but
+            # summing to well beyond it. Each access refreshes its timestamp.
+            for i in range(5):
+                clock.now += 8  # < ttl (10) since the last access
+                self.assertIs(manager.get_container("active"), container)
+                manager.set_container(f"other-{i}", MagicMock())  # triggers sweep
+            self.assertIn("active", manager._run_id_to_container)  # 40s elapsed, alive
+            # Now stop accessing it and let a full TTL pass.
+            clock.now += 11
+            manager.set_container("final", MagicMock())  # sweep
+            self.assertNotIn("active", manager._run_id_to_container)
+        finally:
+            container_mod.time = saved
+
+
+class TestEnvConfigurableTTL(unittest.TestCase):
+    def setUp(self):
+        self._saved = {
+            k: os.environ.get(k)
+            for k in (
+                "MAXIM_CONTAINER_MAPPING_TTL_SECONDS",
+                "MAXIM_GENERATION_STORE_TTL_SECONDS",
+            )
+        }
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_container_ttl_reads_env_at_construction(self):
+        from maxim.logger.models.container import ContainerManager
+
+        os.environ["MAXIM_CONTAINER_MAPPING_TTL_SECONDS"] = "12345"
+        self.assertEqual(ContainerManager()._ttl_seconds, 12345)
+
+    def test_generation_store_ttl_reads_env_at_construction(self):
+        os.environ["MAXIM_GENERATION_STORE_TTL_SECONDS"] = "9999"
+        tracer = make_tracer()
+        self.assertEqual(tracer._generation_store_ttl, 9999)
+
+    def test_malformed_env_falls_back_to_default(self):
+        from maxim.logger.models.container import (
+            DEFAULT_CONTAINER_MAPPING_TTL,
+            ContainerManager,
+        )
+
+        os.environ["MAXIM_CONTAINER_MAPPING_TTL_SECONDS"] = "not-a-number"
+        self.assertEqual(
+            ContainerManager()._ttl_seconds, DEFAULT_CONTAINER_MAPPING_TTL
+        )
+
+    def test_explicit_argument_overrides_env(self):
+        from maxim.logger.models.container import ContainerManager
+
+        os.environ["MAXIM_CONTAINER_MAPPING_TTL_SECONDS"] = "12345"
+        self.assertEqual(ContainerManager(ttl_seconds=42)._ttl_seconds, 42)
+
+
+class TestLongRunningTrace(LifecycleAssertions):
+    def test_long_single_llm_call_still_finds_its_container(self):
+        # A single LLM call that outruns the store TTL: the generation result
+        # is logged (keyed by run_id) and the container survives via
+        # refresh-on-access driven by the run's own start callback, so the
+        # terminal callback still releases cleanly rather than resurrecting a
+        # fragment. Uses a tiny store TTL to simulate a call longer than it.
+        os.environ["MAXIM_GENERATION_STORE_TTL_SECONDS"] = "1"
+        try:
+            tracer = make_tracer()
+        finally:
+            os.environ.pop("MAXIM_GENERATION_STORE_TTL_SECONDS", None)
+        run_id = uuid.uuid4()
+        tracer.on_chat_model_start(
+            {"name": "ChatOpenAI"},
+            [[]],
+            run_id=run_id,
+            parent_run_id=None,
+            metadata={"maxim": {"session_id": "s"}},
+            invocation_params={"model": "gpt-4o"},
+        )
+        # Simulate the store entry expiring during a very long call.
+        time.sleep(1.1)
+        # The result must still be logged, and cleanup must still complete.
+        tracer.on_llm_end(llm_result(), run_id=run_id, parent_run_id=None)
+        self.assertTrue(tracer.logger.generation_result.called)
+        self.assertNoneRetained(tracer)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/maxim/tests/test_writer_backpressure.py
+++ b/maxim/tests/test_writer_backpressure.py
@@ -1,0 +1,215 @@
+"""
+Tests for LogWriter durability and memory bounds.
+
+The writer must never drop a log, and must not grow without bound when the
+backend is slow or unreachable. Those two requirements pull against each other:
+the resolution is that overflow goes to disk rather than into memory or the
+bin.
+"""
+
+import os
+import shutil
+import tempfile
+import threading
+import time
+import unittest
+from unittest.mock import MagicMock
+
+from maxim.logger.components.types import CommitLog, Entity
+from maxim.logger.writer import (
+    MAX_FILE_REPLAY_ATTEMPTS,
+    MAX_IN_FLIGHT_BATCHES,
+    LogWriter,
+    LogWriterConfig,
+)
+
+
+def make_writer(tmpdir, **overrides):
+    config = LogWriterConfig(
+        base_url="http://localhost",
+        api_key="test",
+        repository_id="repo-1",
+        auto_flush=False,
+        flush_interval=10,
+        **overrides,
+    )
+    writer = LogWriter(config)
+    writer.maxim_api = MagicMock()
+    writer.logs_dir = tmpdir
+    os.makedirs(tmpdir, exist_ok=True)
+    return writer
+
+
+def log(n=0):
+    return CommitLog(Entity.TRACE, f"t{n}", "create", {"name": f"trace-{n}"})
+
+
+def spilled_files(tmpdir):
+    return sorted(f for f in os.listdir(tmpdir) if f.endswith(".log"))
+
+
+class WriterTestCase(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="maxim-writer-test-")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+
+class TestSpillFilenames(WriterTestCase):
+    def test_two_spills_in_the_same_second_do_not_overwrite(self):
+        # The filename used to be second-resolution and opened truncating, so
+        # a burst of failures silently destroyed all but the last batch.
+        writer = make_writer(self.tmpdir)
+        writer.write_to_file([log(1)])
+        writer.write_to_file([log(2)])
+        self.assertEqual(len(spilled_files(self.tmpdir)), 2)
+
+    def test_spilled_file_contains_every_log(self):
+        writer = make_writer(self.tmpdir)
+        writer.write_to_file([log(1), log(2), log(3)])
+        path = os.path.join(self.tmpdir, spilled_files(self.tmpdir)[0])
+        with open(path) as f:
+            self.assertEqual(len([line for line in f if line.strip()]), 3)
+
+
+class TestMemoryBound(WriterTestCase):
+    def test_batches_spill_to_disk_once_the_executor_is_saturated(self):
+        # The executor's queue is unbounded, so a backend slower than the log
+        # rate used to stack batches in memory until the process died.
+        writer = make_writer(self.tmpdir)
+        release = threading.Event()
+
+        def block(*args, **kwargs):
+            release.wait(timeout=10)
+
+        writer.maxim_api.push_logs.side_effect = block
+        try:
+            for i in range(MAX_IN_FLIGHT_BATCHES + 3):
+                writer.commit(log(i))
+                writer.flush_commit_logs()
+            # Everything past the in-flight limit must be on disk, not queued.
+            self.assertGreater(len(spilled_files(self.tmpdir)), 0)
+        finally:
+            release.set()
+
+    def test_nothing_spills_while_the_backend_keeps_up(self):
+        writer = make_writer(self.tmpdir)
+        for i in range(5):
+            writer.commit(log(i))
+            writer.flush_commit_logs()
+        deadline = time.time() + 5
+        while time.time() < deadline and writer._LogWriter__in_flight > 0:
+            time.sleep(0.02)
+        self.assertEqual(spilled_files(self.tmpdir), [])
+
+    def test_in_flight_counter_returns_to_zero(self):
+        # A counter that leaks upward would permanently force the spill path.
+        writer = make_writer(self.tmpdir)
+        for i in range(3):
+            writer.commit(log(i))
+            writer.flush_commit_logs()
+        deadline = time.time() + 5
+        while time.time() < deadline and writer._LogWriter__in_flight > 0:
+            time.sleep(0.02)
+        self.assertEqual(writer._LogWriter__in_flight, 0)
+
+
+class TestReplay(WriterTestCase):
+    def test_spilled_logs_are_pushed_and_removed(self):
+        writer = make_writer(self.tmpdir)
+        writer.write_to_file([log(1)])
+        writer.flush_log_files()
+        self.assertTrue(writer.maxim_api.push_logs.called)
+        self.assertEqual(spilled_files(self.tmpdir), [])
+
+    def test_failing_file_is_retried_then_quarantined(self):
+        # A file the server will never accept used to be re-read into memory
+        # and retried on every cycle, blocking every file behind it forever.
+        writer = make_writer(self.tmpdir)
+        writer.maxim_api.push_logs.side_effect = Exception("rejected")
+        writer.write_to_file([log(1)])
+        for _ in range(MAX_FILE_REPLAY_ATTEMPTS):
+            writer.flush_log_files()
+        self.assertEqual(spilled_files(self.tmpdir), [])
+        self.assertEqual(
+            len([f for f in os.listdir(self.tmpdir) if f.endswith(".failed")]), 1
+        )
+
+    def test_quarantined_file_is_not_deleted(self):
+        # Quarantine must preserve the data for inspection, not discard it.
+        writer = make_writer(self.tmpdir)
+        writer.maxim_api.push_logs.side_effect = Exception("rejected")
+        writer.write_to_file([log(1)])
+        for _ in range(MAX_FILE_REPLAY_ATTEMPTS):
+            writer.flush_log_files()
+        failed = [f for f in os.listdir(self.tmpdir) if f.endswith(".failed")][0]
+        with open(os.path.join(self.tmpdir, failed)) as f:
+            self.assertIn("trace-1", f.read())
+
+    def test_unreadable_file_is_quarantined_not_retried_forever(self):
+        # A file that cannot even be read used to bypass the failure counter
+        # entirely, so it was retried on every cycle forever and permanently
+        # occupied one of the per-cycle replay slots.
+        writer = make_writer(self.tmpdir)
+        path = os.path.join(self.tmpdir, "logs-corrupt.log")
+        with open(path, "wb") as f:
+            f.write(b"\xff\xfe\x80 not valid utf-8")
+        for _ in range(MAX_FILE_REPLAY_ATTEMPTS):
+            writer.flush_log_files()
+        self.assertEqual(spilled_files(self.tmpdir), [])
+        self.assertEqual(
+            len([f for f in os.listdir(self.tmpdir) if f.endswith(".failed")]), 1
+        )
+        self.assertFalse(writer.maxim_api.push_logs.called)
+
+    def test_transient_failure_does_not_quarantine(self):
+        writer = make_writer(self.tmpdir)
+        writer.maxim_api.push_logs.side_effect = Exception("network blip")
+        writer.write_to_file([log(1)])
+        writer.flush_log_files()
+        # Still pending, not quarantined, after a single failure.
+        self.assertEqual(len(spilled_files(self.tmpdir)), 1)
+        writer.maxim_api.push_logs.side_effect = None
+        writer.flush_log_files()
+        self.assertEqual(spilled_files(self.tmpdir), [])
+
+    def test_raise_exceptions_propagates_push_failure(self):
+        # The outer filesystem guard used to swallow the deliberate re-raise,
+        # so raise_exceptions=True never actually surfaced replay failures.
+        writer = make_writer(self.tmpdir, raise_exceptions=True)
+        cause = Exception("rejected")
+        writer.maxim_api.push_logs.side_effect = cause
+        writer.write_to_file([log(1)])
+        with self.assertRaises(Exception) as ctx:
+            writer.flush_log_files()
+        self.assertIs(ctx.exception.__cause__, cause)
+        # The replay lock must have been released on the way out.
+        writer.maxim_api.push_logs.side_effect = None
+        writer.flush_log_files()
+        self.assertEqual(spilled_files(self.tmpdir), [])
+
+    def test_concurrent_replay_does_not_duplicate_logs(self):
+        # flush_log_files now runs on several workers; two of them reading the
+        # same file would push those logs twice.
+        writer = make_writer(self.tmpdir)
+        pushed = []
+        lock = threading.Lock()
+
+        def record(repo_id, content):
+            time.sleep(0.05)
+            with lock:
+                pushed.append(content)
+
+        writer.maxim_api.push_logs.side_effect = record
+        writer.write_to_file([log(1)])
+        threads = [threading.Thread(target=writer.flush_log_files) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        self.assertEqual(len(pushed), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "maxim-py"
-version = "3.14.19"
+version = "3.14.20"
 description = "A package that allows you to use the Maxim Python Library to interact with the Maxim Platform."
 readme = "README.md"
 requires-python = ">=3.9.20"


### PR DESCRIPTION
### TL;DR

Release v3.14.20 with several bug fixes around log serialization, memory management, and LangChain tracer correctness.

### What changed?

- Fixed `mappingproxy` serialization errors in log payloads by unifying scalar handling across both log serializers.
- Compacted `modelParameters` serialization so class references emit type names instead of full JSON schemas, and duplicate structured-output schemas are collapsed, resulting in ~10x smaller generation payloads.
- Fixed container and generation store leaks in `MaximLangchainTracer` for runs that pass `session_id` metadata; added the missing `on_retriever_error` handler and root trace cleanup on tool and retriever runs.
- Bounded log writer memory when the backend is slower than the log rate by spilling overflow batches to disk and replaying them later, ensuring no logs are dropped.
- Hardened spilled log replay with unique spill filenames, quarantine of persistently failing files as `.failed`, and proper propagation of replay failures when `raise_exceptions` is set.
- Added `MAXIM_CONTAINER_MAPPING_TTL_SECONDS` and `MAXIM_GENERATION_STORE_TTL_SECONDS` environment variables to tune idle-container cleanup TTL (default raised to 1 hour, refreshed on activity so long-running traces are never swept mid-run).

### How to test?

- Verify log payloads containing `mappingproxy` objects serialize without errors.
- Confirm generation payloads are significantly smaller by inspecting `modelParameters` output before and after.
- Run LangChain tracer integration tests with `session_id` metadata to confirm no container or generation store leaks occur.
- Simulate a slow backend to confirm overflow batches spill to disk and are replayed without log loss.
- Set `MAXIM_CONTAINER_MAPPING_TTL_SECONDS` and `MAXIM_GENERATION_STORE_TTL_SECONDS` and verify TTL behavior changes accordingly.

### Why make this change?

These fixes address reliability and correctness issues in log serialization, memory usage under high log rates, and LangChain tracer resource management. The TTL configurability ensures long-running traces are not prematurely cleaned up in production environments.