### PR TITLE
feat: adds resolved messages to yielded output

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ On `generation.result` events, the callback is invoked with a payload containing
 
 ## Version changelog
 
+### 3.14.21
+
+- feat: Exposes the resolved prompt input messages (system + user, with variables interpolated) to evaluator variable mappings on prompt-version test runs. The mapping `run` object now returns them via `run.get("messages")`, `run.get("input_messages")`, or `run.get("resolved_messages")` — e.g. map a `system_prompt` evaluator variable to the run's resolved system message instead of a dataset column.
+
 ### 3.14.20
 
 - fix: Fixes `mappingproxy` serialization errors in log payloads by unifying scalar handling across both log serializers

--- a/maxim/models/evaluator.py
+++ b/maxim/models/evaluator.py
@@ -551,7 +551,10 @@ class VariableMappingInput:
     Attributes:
         data: The main output string from the run
         retrieved_context_to_evaluate: Optional context retrieved during the run
-        messages: Optional list of messages from the run (conversation history for simulation)
+        messages: Optional list of messages from the run. For simulations this is the
+            conversation history; for prompt-version runs this is the resolved input
+            messages sent to the model (system + user, with variables interpolated).
+            Also accessible as run.get("input_messages") / run.get("resolved_messages").
         meta: Optional metadata including usage and cost information
         simulation_outputs: Optional list of outputs from each simulation turn
         simulation_meta: Optional full simulation metadata (messages, usage, cost, etc.)
@@ -570,7 +573,7 @@ class VariableMappingInput:
             return self.data
         elif key == "retrieved_context_to_evaluate" or key == "retrieval":
             return self.retrieved_context_to_evaluate
-        elif key == "messages":
+        elif key == "messages" or key == "input_messages" or key == "resolved_messages":
             return self.messages
         elif key == "meta":
             return self.meta

--- a/maxim/test_runs/test_run_builder.py
+++ b/maxim/test_runs/test_run_builder.py
@@ -1460,6 +1460,7 @@ class TestRunBuilder(Generic[T]):
                                 yielded_output = YieldedOutput(
                                     data=output_text,
                                     retrieved_context_to_evaluate=self._config.prompt_version.context_to_evaluate,
+                                    messages=prompt_response.resolved_messages or None,
                                     meta=YieldedOutputMeta(
                                         entity_type="PROMPT",
                                         entity_id=self._config.prompt_version.id,
@@ -1827,6 +1828,7 @@ class TestRunBuilder(Generic[T]):
                                 yielded_output = YieldedOutput(
                                     data=output_text,
                                     retrieved_context_to_evaluate=self._config.prompt_version.context_to_evaluate,
+                                    messages=prompt_response.resolved_messages or None,
                                     meta=YieldedOutputMeta(
                                         entity_type="PROMPT",
                                         entity_id=self._config.prompt_version.id,

--- a/maxim/tests/test_test_runs.py
+++ b/maxim/tests/test_test_runs.py
@@ -22,6 +22,7 @@ from maxim.models import (
 from maxim.models.evaluator import (
     PassFailCriteriaForTestrunOverall,
     PassFailCriteriaOnEachEntry,
+    VariableMappingInput,
 )
 
 with open(str(f"{os.getcwd()}/maxim/tests/testConfig.json")) as f:
@@ -884,3 +885,62 @@ class TestTestRuns(unittest.TestCase):
         # Clear singleton instance
         if hasattr(Maxim, "_instance"):
             delattr(Maxim, "_instance")
+
+
+class TestVariableMappingResolvedMessages(unittest.TestCase):
+    """
+    Offline tests for exposing a prompt run's resolved input messages
+    (system + user, variables interpolated) to evaluator variable mappings.
+
+    These run without a live Maxim instance / network, unlike TestTestRuns.
+    """
+
+    def _run(self, messages):
+        yielded = YieldedOutput(
+            data="Here is the summary.",
+            messages=messages,
+            meta=YieldedOutputMeta(
+                entity_type="PROMPT",
+                entity_id="pv_123",
+                usage=YieldedOutputTokenUsage(
+                    prompt_tokens=1, completion_tokens=2, total_tokens=3, latency=0.1
+                ),
+            ),
+        )
+        return VariableMappingInput.from_yielded_output(
+            output=yielded, input_value="Summarize the labs."
+        )
+
+    def test_resolved_messages_are_exposed_to_mapping(self):
+        resolved = [
+            {"role": "system", "content": "You are a careful clinical assistant."},
+            {"role": "user", "content": "Summarize the labs."},
+        ]
+        run = self._run(resolved)
+
+        # All three access keys return the resolved input messages
+        self.assertEqual(run.get("messages"), resolved)
+        self.assertEqual(run.get("input_messages"), resolved)
+        self.assertEqual(run.get("resolved_messages"), resolved)
+        self.assertEqual(run.messages, resolved)
+
+        # A system_prompt mapping can be sourced from the run instead of a dataset column
+        system_prompt = lambda run, dataset, version: next(
+            (m["content"] for m in (run.get("messages") or []) if m.get("role") == "system"),
+            "",
+        )
+        self.assertEqual(
+            system_prompt(run, {}, None), "You are a careful clinical assistant."
+        )
+
+        # Output/input aliases keep working alongside messages
+        self.assertEqual(run.data, "Here is the summary.")
+        self.assertEqual(run.get("output"), "Here is the summary.")
+        self.assertEqual(run.get("input"), "Summarize the labs.")
+
+    def test_absent_messages_stay_none(self):
+        # No resolved messages (e.g. workflow/yields_output runs) -> None, not [].
+        run = self._run(None)
+        self.assertIsNone(run.get("messages"))
+        self.assertIsNone(run.get("input_messages"))
+        self.assertIsNone(run.get("resolved_messages"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "maxim-py"
-version = "3.14.20"
+version = "3.14.21"
 description = "A package that allows you to use the Maxim Python Library to interact with the Maxim Platform."
 readme = "README.md"
 requires-python = ">=3.9.20"


### PR DESCRIPTION
### TL;DR

Exposes resolved prompt input messages (system + user, with variables interpolated) to evaluator variable mappings during prompt-version test runs.

### What changed?

The `VariableMappingInput.get()` method now accepts two additional key aliases — `"input_messages"` and `"resolved_messages"` — that return the same value as `"messages"`. For prompt-version test runs, the `messages` field is now populated with the resolved input messages sent to the model (system + user messages with variables interpolated), making them accessible via `run.get("messages")`, `run.get("input_messages")`, or `run.get("resolved_messages")`.

The `YieldedOutput` construction in both `process_row` and `process_dataset_entry` now passes `prompt_response.resolved_messages` into the `messages` field, wiring the resolved messages through to the evaluator mapping layer.

### How to test?

A new offline test class `TestVariableMappingResolvedMessages` covers the key scenarios:

- Verify that all three key aliases (`messages`, `input_messages`, `resolved_messages`) return the resolved input messages when present.
- Verify that a `system_prompt` evaluator variable can be sourced directly from the run's resolved messages (e.g. filtering by `role == "system"`) rather than from a dataset column.
- Verify that when no resolved messages are present (e.g. workflow runs), all three aliases return `None` rather than an empty list.

### Why make this change?

Previously, evaluator variable mappings had no way to reference the actual system or user prompt sent to the model during a prompt-version test run. This made it impossible to evaluate against the resolved prompt content without duplicating it in a dataset column. By surfacing the resolved input messages on the `run` object, evaluators can now directly map variables like `system_prompt` to the run's resolved system message.